### PR TITLE
Fix: centralize current day when loading

### DIFF
--- a/script.js
+++ b/script.js
@@ -598,6 +598,17 @@ document.addEventListener("DOMContentLoaded", async function () {
   updateAllRewardProgress();
   countStats();
 
+  // Centraliza o dia atual na tela
+  function centerTodayInView() {
+    const calendario = document.getElementById('calendario');
+    const todayRow = document.getElementById(`mainrow-dia-${anoAtual}-${mesAtual}-${diaAtual}`);
+    if (calendario && todayRow) {
+      const offset = todayRow.offsetTop - (calendario.clientHeight / 2) + (todayRow.clientHeight / 2);
+      calendario.scrollTop = offset;
+    }
+  }
+  centerTodayInView();
+
   // Responsividade confetti
   window.addEventListener('resize', function () {
     const canvas = document.getElementById('confetti-canvas');


### PR DESCRIPTION
## Summary
- scroll calendar so today's row starts centered in the arcade screen

## Testing
- `node --version`


------
https://chatgpt.com/codex/tasks/task_e_684039fbf5f4832cad11a29cf8a7b21f