### PR TITLE
Fix missing braces in centerTodayDropdown

### DIFF
--- a/script.js
+++ b/script.js
@@ -607,6 +607,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       setTimeout(() => {
         todayDrop.scrollIntoView({ block: 'center' });
       }, 350);
+    }
+  }
+  centerTodayDropdown();
 
   // Responsividade confetti
   window.addEventListener('resize', function () {


### PR DESCRIPTION
## Summary
- close braces and call function to center current day dropdown

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_684045de16dc832cb9c75aa5979f4ed9