### PR TITLE
Implement neon arrow and pixel styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,11 +66,12 @@
     <source src="https://cdn.jsdelivr.net/gh/napthedev/short-audio/success.ogg" type="audio/ogg" />
   </audio>
 
-  <!-- Firebase -->
-  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
-  <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore-compat.js"></script>
+    <!-- Firebase -->
+    <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.0/firebase-firestore-compat.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/twemoji/14.0.2/twemoji.min.js"></script>
 
-  <!-- Script principal -->
-  <script src="script.js"></script>
-</body>
+    <!-- Script principal -->
+    <script src="script.js"></script>
+  </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -266,7 +266,6 @@ document.addEventListener("DOMContentLoaded", async function () {
       <div class="mes-dropdown" id="dropdown-mes-${mesNum}-${anoNum}"><table>
         <thead>
           <tr>
-            <th></th>
             <th>Data</th>
             <th>Hábitos Diários</th>
             <th>Hábito Cíclico</th>
@@ -287,13 +286,12 @@ document.addEventListener("DOMContentLoaded", async function () {
       }
       html += `
         <tr class="main-row arcade-clicavel" data-dropdown="${dia.id}" id="mainrow-${dia.id}">
-          <td><span class="expand-icon">&#9654;</span></td>
           <td class="progress-text gold">${dia.data}</td>
           <td class="progress-text gold">${habitosCellText}</td>
           <td class="progress-text gold">${dia.ciclico}</td>
         </tr>
         <tr class="dropdown" id="dropdown-${dia.id}" style="display: none;">
-          <td colspan="4">
+          <td colspan="3">
             <div class="habit-list">
               ${dia.habitos.map((h, idx) => `
                 <div class="habit-item arcade-clicavel" id="habititem-${dia.id}-habit-${idx}">
@@ -327,6 +325,9 @@ document.addEventListener("DOMContentLoaded", async function () {
     html += `</div>`; // fecha o .mes-dropdown
   });
   calendario.innerHTML = html;
+  if (window.twemoji) {
+    twemoji.parse(calendario, {folder: 'svg', ext: '.svg'});
+  }
 
   // --- CONTINUAÇÃO ABAIXO ---
   // Dropdown lógica: abrir/fechar MÊS e DIAS
@@ -344,9 +345,9 @@ document.addEventListener("DOMContentLoaded", async function () {
     const mesNum = parseInt(mesDiv.getAttribute("data-mes"));
     const anoNum = parseInt(mesDiv.getAttribute("data-ano"));
     const dropdown = allDropdowns[idx];
-    // Setas animadas
+    // Indicador de mês atual
     mesDiv.querySelector(".arcade-arrow").innerHTML = (mesNum === mesAtual && anoNum === anoAtual) ?
-      `<span class="current-indicator"></span>` : `<span class="arrow-inactive">&#9654;</span>`;
+      `<span class="neon-arrow"></span>` : '';
     // Só abre o mês atual
     if (mesNum === mesAtual && anoNum === anoAtual) {
       dropdown.style.display = 'block';
@@ -373,7 +374,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const mNum = parseInt(allMesDivs[i].getAttribute("data-mes"));
         const aNum = parseInt(allMesDivs[i].getAttribute("data-ano"));
         allMesDivs[i].querySelector(".arcade-arrow").innerHTML = (mNum === mesAtual && aNum === anoAtual) ?
-          `<span class="current-indicator"></span>` : `<span class="arrow-inactive">&#9654;</span>`;
+          `<span class="neon-arrow"></span>` : '';
         if (allRewards[i]) {
           allRewards[i].style.display = 'none';
         }
@@ -384,7 +385,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       setTimeout(() => dropdown.classList.add('arcade-drop-show'), 5);
       mesDiv.classList.add('open', 'mes-atual');
       mesDiv.querySelector(".arcade-arrow").innerHTML = (mesNum === mesAtual && anoNum === anoAtual) ?
-        `<span class="current-indicator"></span>` : `<span class="arrow-pulse">&#9654;</span>`;
+        `<span class="neon-arrow"></span>` : '';
       if (allRewards[idx]) {
         allRewards[idx].style.display = '';
       }
@@ -398,7 +399,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       // Abre dia atual, se for este mês
       if (mesNum === mesAtual && anoNum === anoAtual) {
         let idxDia = Array.from(dropdown.querySelectorAll('.main-row')).findIndex(row => {
-          let dateCell = row.querySelectorAll('td')[1];
+          let dateCell = row.querySelectorAll('td')[0];
           if (!dateCell) return false;
           let d = parseInt(dateCell.innerText.split("/")[0]);
           return d === diaAtual;
@@ -422,13 +423,10 @@ document.addEventListener("DOMContentLoaded", async function () {
     rows.forEach((row, idx) => {
       const dropRow = dropdown.querySelectorAll('.dropdown')[idx];
       // Só abre o dia atual do mês atual
-      let dateCell = row.querySelectorAll('td')[1];
+      let dateCell = row.querySelectorAll('td')[0];
       let d = parseInt(dateCell ? dateCell.innerText.split("/")[0] : 0);
-      const icon = row.querySelector('.expand-icon');
       if (mesNum === mesAtual && anoNum === anoAtual && d === diaAtual) {
-        if (icon) icon.innerHTML = '<span class="current-indicator"></span>';
-      } else if (icon) {
-        icon.innerHTML = '&#9654;';
+        row.classList.add('current-day');
       }
       if (mesNum === mesAtual && anoNum === anoAtual && d === diaAtual) {
         dropRow.style.display = 'table-row';
@@ -451,9 +449,6 @@ document.addEventListener("DOMContentLoaded", async function () {
           dr.style.display = 'none';
           dr.classList.remove('arcade-drop-show');
           r.classList.remove('expanded');
-          const ic = r.querySelector('.expand-icon');
-          const dd = parseInt(r.querySelectorAll('td')[1].innerText.split('/')[0]);
-          if (ic) ic.innerHTML = (mesNum === mesAtual && anoNum === anoAtual && dd === diaAtual) ? '<span class="current-indicator"></span>' : '&#9654;';
         });
         if (wasOpen) return;
         // Abre clicado

--- a/style.css
+++ b/style.css
@@ -108,6 +108,28 @@ html, body {
   border: none !important;
   cursor: default;
   user-select: none;
+  position: relative;
+}
+
+#calendario::before,
+#calendario::after {
+  content: '';
+  position: sticky;
+  left: 0;
+  right: 0;
+  height: 35px;
+  pointer-events: none;
+  z-index: 20;
+}
+
+#calendario::before {
+  top: 0;
+  background: linear-gradient(to bottom, #00253b, transparent);
+}
+
+#calendario::after {
+  bottom: 0;
+  background: linear-gradient(to top, #00253b, transparent);
 }
 #calendario, #calendario th, #calendario td, #calendario .progress-text,
 #calendario .mes, #calendario .habit-label, #calendario .habit-emoji, #calendario .habit-item {
@@ -116,6 +138,12 @@ html, body {
 #calendario .habit-emoji {
   filter: drop-shadow(0 0 6px #51ffe7cc) drop-shadow(0 0 8px #ffe37966);
   font-size: 1.6em;
+}
+
+.emoji {
+  width: 1em;
+  height: 1em;
+  image-rendering: pixelated;
 }
 
 /* === MES === */
@@ -134,53 +162,60 @@ html, body {
   transition: color 0.17s cubic-bezier(.47,1.64,.41,.88);
   padding: 0 0 0 0;
 }
+.arcade-arrow {
+  position: absolute;
+  left: 0;
+  top: 0;
+}
 .mes .mes-label { z-index: 2; }
-.arcade-pointer {
-  display: none;
-  width: 38px; height: 38px; margin-left: 0;
-  margin-right: -36px;
-  filter: drop-shadow(0 0 17px #31fcff) drop-shadow(0 0 26px #51ffe7cc);
-  animation: arcade-pointer-bounce 0.9s infinite alternate;
-  position: absolute; left: -44px; top: 10px; z-index: 3;
-}
-@keyframes arcade-pointer-bounce {
-  0% { transform: scale(1) translateY(0);}
-  100% { transform: scale(1.18) translateY(-13px);}
-}
-
-.mes.open .arcade-pointer { display: block !important; }
 .mes:hover { color: #51ffe7; text-shadow: 0 0 16px #51ffe788, 0 0 40px #ffe37944; }
 .mes:active { transform: scale(0.97); }
-.mes:not(.open) .arcade-pointer { display: none !important; }
 .mes:not(.open) { opacity: 0.85; }
 
-.current-indicator {
-  display: inline-block;
-  width: 24px;
-  height: 24px;
-  border-radius: 50%;
-  background: radial-gradient(circle, #51ffe7 40%, transparent 60%);
-  box-shadow: 0 0 8px #51ffe7, 0 0 16px #31fcff;
-  animation: indicator-pulse 1.2s infinite alternate;
+.neon-arrow {
+  position: absolute;
+  left: -50px;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-top: 12px solid transparent;
+  border-bottom: 12px solid transparent;
+  border-right: 34px solid var(--mes-arrow);
+  filter: drop-shadow(0 0 6px var(--mes-arrow)) drop-shadow(0 0 12px var(--mes-arrow));
+  animation: arrow-move 0.8s infinite alternate;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 
-@keyframes indicator-pulse {
-  0% { transform: scale(1); }
-  100% { transform: scale(1.25); }
+.mes-atual .neon-arrow,
+tr.main-row.current-day::before {
+  border-right-color: var(--mes-arrow-ativo);
 }
 
-tr.main-row .arcade-pointer.pointer-dia {
-  display: none;
-  position: absolute; left: -36px; top: 7px; z-index: 4;
-  width: 32px; height: 32px;
-  animation: arcade-pointer-bounce 1.1s infinite alternate;
+@keyframes arrow-move {
+  0% { transform: translate(-3px, -50%); }
+  100% { transform: translate(3px, -50%); }
 }
-tr.main-row.expanded .arcade-pointer.pointer-dia {
-  display: block !important;
+
+tr.main-row.current-day {
+  position: relative;
 }
-tr.main-row:not(.expanded) .arcade-pointer.pointer-dia {
-  display: none !important;
+tr.main-row.current-day::before {
+  content: '';
+  position: absolute;
+  left: -50px;
+  top: 50%;
+  width: 0;
+  height: 0;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+  border-right: 28px solid var(--mes-arrow);
+  filter: drop-shadow(0 0 6px var(--mes-arrow)) drop-shadow(0 0 12px var(--mes-arrow));
+  animation: arrow-move 0.8s infinite alternate;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
+
 
 /* ========== TABELA ========== */
 table {
@@ -271,7 +306,7 @@ tr.dropdown[style*="display: none;"] {
 .habit-checkbox {
   width: 28px; height: 28px; border-radius: 4px;
   margin-left: 8px;
-  background: repeating-linear-gradient(45deg,#222 0 2px,#000 2px 4px);
+  background: repeating-linear-gradient(45deg,#222 0 4px,#000 4px 8px);
   border: 2px solid var(--neon);
   box-shadow: 0 0 5px #51ffe7bb;
   outline: none;
@@ -282,6 +317,7 @@ tr.dropdown[style*="display: none;"] {
   font-family: 'Press Start 2P', monospace;
   color: var(--highlight);
   text-align: center;
+  image-rendering: pixelated;
 }
 .habit-checkbox:checked {
   border-color: var(--highlight);
@@ -296,6 +332,7 @@ tr.dropdown[style*="display: none;"] {
   font-size: 18px;
   line-height: 28px;
   text-shadow: 0 0 5px var(--highlight);
+  filter: drop-shadow(0 0 3px var(--highlight));
 }
 
 /* ==== PRÊMIOS ==== */
@@ -306,9 +343,27 @@ tr.dropdown[style*="display: none;"] {
   width: 89%; max-width: 650px; border: none !important; filter: none;
   position: relative; z-index: 5; box-shadow: none !important;
   box-shadow: 0 0 26px #51ffe766, 0 0 30px #ffe37920;
+  overflow: hidden;
 }
 .reward-card {
   animation: reward-glow 3s ease-in-out infinite;
+}
+
+.reward-card::before {
+  content: '';
+  position: absolute;
+  inset: -6px;
+  border-radius: inherit;
+  background: radial-gradient(circle at center, rgba(81,255,231,0.35), rgba(207,40,255,0.35));
+  filter: blur(18px);
+  animation: reward-rgb 4s ease-in-out infinite;
+  z-index: 1;
+}
+
+@keyframes reward-rgb {
+  0% { background: radial-gradient(circle at center, rgba(81,255,231,0.35), rgba(207,40,255,0.35)); }
+  50% { background: radial-gradient(circle at center, rgba(207,40,255,0.35), rgba(81,255,231,0.35)); }
+  100% { background: radial-gradient(circle at center, rgba(81,255,231,0.35), rgba(207,40,255,0.35)); }
 }
 
 @keyframes reward-glow {


### PR DESCRIPTION
## Summary
- style calendar container with fade edges
- show neon arrows for current month and day
- remove day pointer icons
- replace emojis and checkboxes with pixelated style
- add subtle RGB pulse behind rewards
- include Twemoji parsing for emojis

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68405a909d14832cbaa1c7659e846370