### PR TITLE
Add fade fix and adjust counters

### DIFF
--- a/script.js
+++ b/script.js
@@ -329,6 +329,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   if (window.twemoji) {
     twemoji.parse(calendario, {folder: '72x72', ext: '.png'});
   }
+  calendario.classList.add('loaded');
 
   // --- CONTINUAÇÃO ABAIXO ---
   // Dropdown lógica: abrir/fechar MÊS e DIAS

--- a/style.css
+++ b/style.css
@@ -93,13 +93,13 @@ html, body {
 }
 
 #seguidos-counter {
-  left: 420px;
-  top: 55px;
+  left: calc(420px - 1cm);
+  top: calc(55px - 3cm);
 }
 
 #feitos-counter {
-  left: 1170px;
-  top: 55px;
+  left: calc(1170px + 1cm);
+  top: calc(55px - 3cm);
 }
 
 /* ========== TELA PRINCIPAL CRT ========== */
@@ -147,6 +147,13 @@ html, body {
   height: 35px;
   pointer-events: none;
   z-index: 20;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+}
+
+#calendario.loaded::before,
+#calendario.loaded::after {
+  opacity: 1;
 }
 
 #calendario::before {


### PR DESCRIPTION
## Summary
- fix fade effect glitch on calendar load by hiding pseudo elements until content is ready
- reposition counters using cm units to shift them slightly

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844d4faedd0832caa7197074ad07b78