### PR TITLE
Add celebration confetti on daily completion

### DIFF
--- a/script.js
+++ b/script.js
@@ -492,8 +492,22 @@ document.addEventListener("DOMContentLoaded", async function () {
     let pct = checked / habitCount;
     const row = document.getElementById(`mainrow-${dayId}`);
     if (row) {
-      if (pct === 1) row.classList.add('day-complete');
-      else row.classList.remove('day-complete');
+      const wasComplete = row.classList.contains('day-complete');
+      if (!row.dataset.initDone) {
+        row.dataset.initDone = 'true';
+      } else if (pct === 1 && !wasComplete) {
+        row.classList.add('day-complete');
+        launchConfettiEpic();
+        const audio = document.getElementById('celebrate-audio');
+        if (audio) {
+          audio.currentTime = 0;
+          audio.play().catch(() => {});
+        }
+      } else if (pct === 1) {
+        row.classList.add('day-complete');
+      } else {
+        row.classList.remove('day-complete');
+      }
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -466,3 +466,29 @@ tr.dropdown[style*="display: none;"] {
   .counter-value { font-size: 1.09em; }
   .mes { font-size: 1.1em;}
 }
+
+/* ====== Confetti Celebration ====== */
+#confetti-canvas, #reward-confetti {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  z-index: 2000;
+  pointer-events: none;
+  display: none;
+}
+
+#celebrate-text {
+  position: fixed;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 3.5em;
+  color: #ffe379;
+  text-shadow: 0 0 20px #51ffe7, 0 0 40px #cf28ff;
+  z-index: 2001;
+  display: none;
+  pointer-events: none;
+}


### PR DESCRIPTION
## Summary
- add confetti overlay styles
- trigger celebratory confetti and sound when a day is fully completed

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844db4250b8832c82aa51d0a08474f0