### PR TITLE
Add party lights and confetti tweaks

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,6 +57,7 @@
   <!-- Confetti e celebração -->
   <canvas id="confetti-canvas"></canvas>
   <canvas id="reward-confetti"></canvas>
+<div id="party-lights"></div>
   <div id="celebrate-text">VAI MLK!!!</div>
   <audio id="celebrate-audio">
     <source src="https://cdn.jsdelivr.net/gh/napthedev/short-audio/success.mp3" type="audio/mpeg" />

--- a/script.js
+++ b/script.js
@@ -66,7 +66,7 @@ function launchConfettiEpic() {
   let W = canvas.width, H = canvas.height;
   let particles = [];
   let colors = ['#ffe379','#e4c145','#f7e399','#FF522E','#fafff9','#FFD700','#FF69B4','#00E6F6','#82FF6A','#FF6666','#0ed156','#001130','#fd2a49'];
-  for (let i = 0; i < 1200; i++) {
+  for (let i = 0; i < 2000; i++) {
     particles.push({
       x: Math.random() * W,
       y: Math.random() * -H,
@@ -109,14 +109,17 @@ function launchConfettiEpic() {
   }
   let interval = setInterval(draw, 13);
   const celebrateText = document.getElementById('celebrate-text');
+  const lights = document.getElementById('party-lights');
   celebrateText.style.display = 'block';
+  if (lights) lights.style.display = 'block';
   setTimeout(() => {
     clearInterval(interval);
     ctx.clearRect(0, 0, W, H);
     canvas.style.display = 'none';
     celebrateText.style.display = 'none';
+    if (lights) lights.style.display = 'none';
     document.body.style.overflow = "";
-  }, 4000);
+  }, 7000);
 }
 
 function launchRewardConfetti() {
@@ -125,10 +128,12 @@ function launchRewardConfetti() {
   canvas.width = window.innerWidth;
   canvas.height = window.innerHeight;
   canvas.style.display = 'block';
+  const lights = document.getElementById('party-lights');
+  if (lights) lights.style.display = 'block';
   let W = canvas.width, H = canvas.height;
   let particles = [];
   let colors = ['#cf28ff', '#ff49e1', '#51ffe7', '#fff', '#9800cc', '#29012e'];
-  for (let i = 0; i < 800; i++) {
+  for (let i = 0; i < 1200; i++) {
     particles.push({
       x: Math.random() * W,
       y: Math.random() * -H,
@@ -174,7 +179,8 @@ function launchRewardConfetti() {
     clearInterval(interval);
     ctx.clearRect(0, 0, W, H);
     canvas.style.display = 'none';
-  }, 3400);
+    if (lights) lights.style.display = 'none';
+  }, 6000);
 }
 
 // =================== Progress Save/Load ===================
@@ -518,13 +524,17 @@ document.addEventListener("DOMContentLoaded", async function () {
     const unlocked = document.getElementById(`reward-unlocked-${month}-${year}`);
     if (bar) {
       bar.style.width = (pct * 100) + "%";
+      const celebrateKey = `reward-celebrated-${month}-${year}`;
+      const already = localStorage.getItem(celebrateKey) === 'true';
       if (pct === 1) {
-        if (unlocked.style.display !== "block") {
-          unlocked.style.display = "block";
+        unlocked.style.display = "block";
+        if (!already) {
           launchRewardConfetti();
+          localStorage.setItem(celebrateKey, 'true');
         }
       } else {
         unlocked.style.display = "none";
+        localStorage.removeItem(celebrateKey);
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -468,6 +468,25 @@ tr.dropdown[style*="display: none;"] {
 }
 
 /* ====== Confetti Celebration ====== */
+#party-lights {
+  position: fixed;
+  left: 0;
+  top: 0;
+  width: 100vw;
+  height: 100vh;
+  pointer-events: none;
+  display: none;
+  z-index: 1999;
+  background: radial-gradient(circle at 20% 20%, rgba(255,0,255,0.4), transparent 60%),
+              radial-gradient(circle at 80% 30%, rgba(0,255,255,0.4), transparent 60%),
+              radial-gradient(circle at 50% 80%, rgba(255,255,0,0.4), transparent 60%);
+  animation: partyHue 3s linear infinite;
+}
+@keyframes partyHue {
+  0% { filter: hue-rotate(0deg); }
+  100% { filter: hue-rotate(360deg); }
+}
+
 #confetti-canvas, #reward-confetti {
   position: fixed;
   left: 0;
@@ -484,6 +503,7 @@ tr.dropdown[style*="display: none;"] {
   left: 50%;
   top: 50%;
   transform: translate(-50%, -50%);
+  animation: textBounce 1.2s ease-in-out infinite;
   font-family: 'Press Start 2P', monospace;
   font-size: 3.5em;
   color: #ffe379;
@@ -491,4 +511,9 @@ tr.dropdown[style*="display: none;"] {
   z-index: 2001;
   display: none;
   pointer-events: none;
+}
+
+@keyframes textBounce {
+  0%,100% { transform: translate(-50%, -50%) scale(1); }
+  50% { transform: translate(-50%, -55%) scale(1.2); }
 }


### PR DESCRIPTION
## Summary
- add party lights overlay element
- animate celebrate text
- expand confetti particle count and duration
- celebrate rewards only once and longer
- show party lights with confetti

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6844dd5b9d60832c8f215424ccb59416