### PR TITLE
Add start screen overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,8 +35,13 @@
     <source src="Fundo site.mp4" type="video/mp4" />
   </video>
 
+  <div id="start-screen">
+    <div class="start-title">Pronto para tomar o controle da sua vida</div>
+    <div class="press-start">Press Start</div>
+  </div>
+
   <!-- Contadores laterais -->
-  <div class="arcade-counters transparent">
+  <div class="arcade-counters transparent" style="display:none;">
     <div class="counter-box" id="seguidos-counter">
       <span class="counter-label">Dias<br>Seguidos</span>
       <span class="counter-value" id="seqCount">0</span>
@@ -48,7 +53,7 @@
   </div>
 
   <!-- Tela principal CRT -->
-  <div class="arcade-screen-curve">
+  <div class="arcade-screen-curve" style="display:none;">
     <div class="crt-glass-overlay"></div>
     <div class="crt-noise"></div>
     <div id="calendario" class="calendario-container" tabindex="-1"></div>

--- a/script.js
+++ b/script.js
@@ -213,6 +213,15 @@ document.addEventListener("DOMContentLoaded", async function () {
     bgVideo.play().catch(() => {});
   }
 
+  const startScreen = document.getElementById('start-screen');
+  const mainEls = document.querySelectorAll('.arcade-screen-curve, .arcade-counters');
+  function startApp() {
+    startScreen.classList.add('hidden');
+    mainEls.forEach(el => el.style.display = '');
+  }
+  startScreen.addEventListener('click', startApp, { once: true });
+  document.addEventListener('keydown', startApp, { once: true });
+
   const progress = await getProgress();
   const dados = [];
   const habitos_incrementais = {

--- a/style.css
+++ b/style.css
@@ -31,6 +31,47 @@ html, body {
   pointer-events: none;
 }
 
+/* ========== START SCREEN ========== */
+#start-screen {
+  position: fixed;
+  inset: 0;
+  background: var(--crt-dark);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  z-index: 40;
+  text-align: center;
+}
+
+#start-screen .start-title {
+  color: var(--highlight);
+  text-shadow: 0 0 20px var(--neon), 0 0 40px #cf28ff;
+  font-size: 1.1em;
+  margin: 0 20px 40px 20px;
+}
+
+#start-screen .press-start {
+  font-size: 2.4em;
+  color: var(--highlight);
+  text-shadow: 0 0 20px var(--neon), 0 0 40px #cf28ff;
+  animation: press-blink 1s steps(2, start) infinite;
+}
+
+#start-screen.hidden {
+  animation: startFade 0.6s forwards;
+  pointer-events: none;
+}
+
+@keyframes press-blink {
+  0%, 50% { opacity: 1; }
+  50.01%, 100% { opacity: 0; }
+}
+
+@keyframes startFade {
+  to { opacity: 0; visibility: hidden; }
+}
+
 /* ========== BANNER ========== */
 .banner-gamer {
   position: absolute; left: 50%; top: -2px; width: 98vw; max-width: 770px; min-width: 160px;


### PR DESCRIPTION
## Summary
- create Start Screen overlay with animated "Press Start"
- hide counters and calendar until pressing Start

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68457e289b40832c8a71672e45cc8955