### PR TITLE
Add video-first start screen with arcade transition

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,15 @@
     <source src="Fundo site.mp4" type="video/mp4" />
   </video>
 
-  <div id="start-screen">
-    <div class="start-title">Pronto para tomar o controle da sua vida</div>
-    <div class="press-start">Press Start</div>
+  <!-- Tela principal CRT -->
+  <div class="arcade-screen-curve">
+    <div class="crt-glass-overlay"></div>
+    <div class="crt-noise"></div>
+    <div id="start-screen">
+      <div class="start-title">Pronto para tomar o controle da sua vida?</div>
+      <div class="press-start">Press Start</div>
+    </div>
+    <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;"></div>
   </div>
 
   <!-- Contadores laterais -->
@@ -50,13 +56,6 @@
       <span class="counter-label">Hábitos<br>Feitos</span>
       <span class="counter-value" id="doneCount">0</span>
     </div>
-  </div>
-
-  <!-- Tela principal CRT -->
-  <div class="arcade-screen-curve" style="display:none;">
-    <div class="crt-glass-overlay"></div>
-    <div class="crt-noise"></div>
-    <div id="calendario" class="calendario-container" tabindex="-1"></div>
   </div>
 
   <!-- Confetti e celebração -->

--- a/script.js
+++ b/script.js
@@ -218,13 +218,61 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   const startScreen = document.getElementById('start-screen');
-  const mainEls = document.querySelectorAll('.arcade-screen-curve, .arcade-counters');
+  const calendarioEl = document.getElementById('calendario');
+  const countersEl = document.querySelector('.arcade-counters');
+  function openCurrentMonthDay() {
+    const today = new Date();
+    const mesAtual = today.getMonth() + 1;
+    const anoAtual = today.getFullYear();
+    const diaAtual = today.getDate();
+    const allMesDivs = document.querySelectorAll('#calendario .mes');
+    const allDropdowns = document.querySelectorAll('#calendario .mes-dropdown');
+    const allRewards = document.querySelectorAll('#calendario .reward-card');
+    allMesDivs.forEach((mesDiv, idx) => {
+      const mesNum = parseInt(mesDiv.getAttribute('data-mes'));
+      const anoNum = parseInt(mesDiv.getAttribute('data-ano'));
+      const dropdown = allDropdowns[idx];
+      mesDiv.querySelector('.arcade-arrow').innerHTML = mesNum === mesAtual && anoNum === anoAtual ? `<span class="neon-arrow"></span>` : '';
+      dropdown.style.display = 'none';
+      mesDiv.classList.remove('open', 'mes-atual');
+      if (allRewards[idx]) allRewards[idx].style.display = 'none';
+    });
+    allMesDivs.forEach((mesDiv, idx) => {
+      const mesNum = parseInt(mesDiv.getAttribute('data-mes'));
+      const anoNum = parseInt(mesDiv.getAttribute('data-ano'));
+      const dropdown = allDropdowns[idx];
+      if (mesNum === mesAtual && anoNum === anoAtual) {
+        dropdown.style.display = 'block';
+        setTimeout(() => dropdown.classList.add('arcade-drop-show'), 5);
+        mesDiv.classList.add('open', 'mes-atual');
+        mesDiv.querySelector('.arcade-arrow').innerHTML = `<span class="neon-arrow"></span>`;
+        if (allRewards[idx]) allRewards[idx].style.display = '';
+        const rows = dropdown.querySelectorAll('tr.main-row');
+        rows.forEach((row, j) => {
+          const dropRow = dropdown.querySelectorAll('.dropdown')[j];
+          const dateCell = row.querySelectorAll('td')[0];
+          const d = parseInt(dateCell.innerText.split('/')[0]);
+          if (d === diaAtual) {
+            row.classList.add('current-day', 'expanded');
+            dropRow.style.display = 'table-row';
+            setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
+          }
+        });
+      }
+    });
+    centerTodayDropdown();
+  }
+
   function startApp() {
     startScreen.classList.add('hidden');
-    mainEls.forEach(el => el.style.display = '');
+    if (calendarioEl) calendarioEl.style.display = '';
+    if (countersEl) countersEl.style.display = '';
+    openCurrentMonthDay();
   }
   startScreen.addEventListener('click', startApp, { once: true });
-  document.addEventListener('keydown', startApp, { once: true });
+  document.addEventListener('keydown', function(e) {
+    if (e.code === 'Enter' || e.code === 'Space') startApp();
+  }, { once: true });
 
   const progress = await getProgress();
   const dados = [];
@@ -370,7 +418,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const anoAtual = today.getFullYear();
   const diaAtual = today.getDate();
 
-  // Inicializa: todos fechados exceto mês/dia atual
+  // Inicializa: todos fechados
   allMesDivs.forEach((mesDiv, idx) => {
     const mesNum = parseInt(mesDiv.getAttribute("data-mes"));
     const anoNum = parseInt(mesDiv.getAttribute("data-ano"));
@@ -378,22 +426,12 @@ document.addEventListener("DOMContentLoaded", async function () {
     // Indicador de mês atual
     mesDiv.querySelector(".arcade-arrow").innerHTML = (mesNum === mesAtual && anoNum === anoAtual) ?
       `<span class="neon-arrow"></span>` : '';
-    // Só abre o mês atual
-    if (mesNum === mesAtual && anoNum === anoAtual) {
-      dropdown.style.display = 'block';
-      mesDiv.classList.add('open');
-      mesDiv.classList.add('mes-atual');
-      if (allRewards[idx]) {
-        allRewards[idx].style.display = '';
-      }
-    } else {
-      dropdown.style.display = 'none';
-      mesDiv.classList.remove('open');
-      if (allRewards[idx]) {
-        allRewards[idx].style.display = 'none';
-      }
+    dropdown.style.display = 'none';
+    mesDiv.classList.remove('open', 'mes-atual');
+    if (allRewards[idx]) {
+      allRewards[idx].style.display = 'none';
     }
-
+  
     // Evento de abrir/fechar mês (com animação)
     mesDiv.onclick = (e) => {
       const wasOpen = mesDiv.classList.contains('open');
@@ -445,7 +483,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     };
   });
 
-  // Dropdowns de dias: todos fechados exceto dia atual no mês atual
+  // Dropdowns de dias: todos fechados
   document.querySelectorAll('#calendario .mes-dropdown').forEach((dropdown, dIdx) => {
     const rows = dropdown.querySelectorAll('tr.main-row');
     const mesNum = parseInt(allMesDivs[dIdx].getAttribute("data-mes"));
@@ -458,15 +496,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (mesNum === mesAtual && anoNum === anoAtual && d === diaAtual) {
         row.classList.add('current-day');
       }
-      if (mesNum === mesAtual && anoNum === anoAtual && d === diaAtual) {
-        dropRow.style.display = 'table-row';
-        setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
-        row.classList.add('expanded');
-      } else {
-        dropRow.style.display = 'none';
-        dropRow.classList.remove('arcade-drop-show');
-        row.classList.remove('expanded');
-      }
+      dropRow.style.display = 'none';
+      dropRow.classList.remove('arcade-drop-show');
+      row.classList.remove('expanded');
 
       // Evento de abrir/fechar dia
       row.onclick = (e) => {
@@ -670,7 +702,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       }, 350);
     }
   }
-  centerTodayDropdown();
+  // Chamado após abrir mês e dia atuais
 
   // Responsividade confetti
   window.addEventListener('resize', function () {

--- a/style.css
+++ b/style.css
@@ -33,14 +33,14 @@ html, body {
 
 /* ========== START SCREEN ========== */
 #start-screen {
-  position: fixed;
+  position: absolute;
   inset: 0;
   background: var(--crt-dark);
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  z-index: 40;
+  z-index: 20;
   text-align: center;
 }
 


### PR DESCRIPTION
## Summary
- embed the start screen inside the CRT container and show background video first
- hide calendar and counters until start
- animate month/day opening after user starts
- keep start text with question mark

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_684584d8f964832ca11e4761f6a364ff