### PR TITLE
Update start screen behavior

### DIFF
--- a/script.js
+++ b/script.js
@@ -265,9 +265,11 @@ document.addEventListener("DOMContentLoaded", async function () {
 
   function startApp() {
     startScreen.classList.add('hidden');
-    if (calendarioEl) calendarioEl.style.display = '';
-    if (countersEl) countersEl.style.display = '';
-    openCurrentMonthDay();
+    setTimeout(() => {
+      if (calendarioEl) calendarioEl.style.display = '';
+      if (countersEl) countersEl.style.display = '';
+      openCurrentMonthDay();
+    }, 800);
   }
   startScreen.addEventListener('click', startApp, { once: true });
   document.addEventListener('keydown', function(e) {

--- a/style.css
+++ b/style.css
@@ -35,7 +35,7 @@ html, body {
 #start-screen {
   position: absolute;
   inset: 0;
-  background: var(--crt-dark);
+  background: none;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
## Summary
- show only text on the start screen by removing its background
- delay calendar display for a brief blank transition

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68458c0b4ca4832caf923ce6936f0be6