### PR TITLE
Improve transitions and confetti triggers

### DIFF
--- a/script.js
+++ b/script.js
@@ -266,8 +266,14 @@ document.addEventListener("DOMContentLoaded", async function () {
   function startApp() {
     startScreen.classList.add('hidden');
     setTimeout(() => {
-      if (calendarioEl) calendarioEl.style.display = '';
-      if (countersEl) countersEl.style.display = '';
+      if (calendarioEl) {
+        calendarioEl.style.display = '';
+        calendarioEl.classList.add('show-rgb');
+      }
+      if (countersEl) {
+        countersEl.style.display = '';
+        countersEl.classList.add('show-stroke');
+      }
       openCurrentMonthDay();
     }, 800);
   }
@@ -565,7 +571,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
 
   // Prêmios
-  function updateRewardProgress(month, year, totalDias, diasCompletos) {
+  function updateRewardProgress(month, year, totalDias, diasCompletos, skipCelebrate = false) {
     const pct = diasCompletos / totalDias;
     const bar = document.getElementById(`reward-bar-${month}-${year}`);
     const unlocked = document.getElementById(`reward-unlocked-${month}-${year}`);
@@ -575,7 +581,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const already = localStorage.getItem(celebrateKey) === 'true';
       if (pct === 1) {
         unlocked.style.display = "block";
-        if (!already) {
+        if (!already && !skipCelebrate) {
           launchRewardConfetti();
           localStorage.setItem(celebrateKey, 'true');
         }
@@ -598,7 +604,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     return complete;
   }
 
-  function updateAllRewardProgress() {
+  function updateAllRewardProgress(skipCelebrate = false) {
     Object.entries(grupos).forEach(([id, dias]) => {
       const [mes, ano] = id.split("-");
       const reward = getRewardFor(Number(mes), Number(ano));
@@ -609,7 +615,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const allDone = checkAllHabitsComplete(dia.id, habitCount - 1);
         if (allDone) diasCompletos++;
       });
-      updateRewardProgress(mes, ano, dias.length, diasCompletos);
+      updateRewardProgress(mes, ano, dias.length, diasCompletos, skipCelebrate);
     });
   }
 
@@ -654,7 +660,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const dayId = parts[0];
         const habitCount = document.querySelectorAll(`#dropdown-${dayId} .habit-checkbox`).length;
         updateProgressBar(dayId, habitCount);
-        updateAllRewardProgress();
+        updateAllRewardProgress(false);
         countStats();
       }
     });
@@ -690,7 +696,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (dayRow) dayRow.classList.add('day-complete');
     }
   });
-  updateAllRewardProgress();
+  updateAllRewardProgress(true);
   countStats();
 
   // Centraliza visualmente o dropdown do dia atual na tela

--- a/style.css
+++ b/style.css
@@ -97,6 +97,7 @@ html, body {
   pointer-events: none;
   background: none !important;
   transform: none;
+  opacity: 0;
 }
 .counter-label, .counter-value {
   text-align: center; width: 100%; pointer-events: none;
@@ -176,6 +177,7 @@ html, body {
   cursor: default;
   user-select: none;
   position: relative;
+  opacity: 0;
 }
 
 #calendario {
@@ -568,4 +570,43 @@ tr.dropdown[style*="display: none;"] {
 
 .shake-dance {
   animation: danceShake 0.4s linear infinite;
+}
+
+/* === Apresentação com RGB Split === */
+#calendario.show-rgb {
+  animation: rgbSplitIn 0.6s forwards;
+}
+
+@keyframes rgbSplitIn {
+  0% {
+    opacity: 0;
+    filter: drop-shadow(-8px 0 red) drop-shadow(8px 0 cyan);
+    transform: scale(0.95);
+  }
+  50% {
+    filter: drop-shadow(4px 0 red) drop-shadow(-4px 0 cyan);
+  }
+  100% {
+    opacity: 1;
+    filter: none;
+    transform: none;
+  }
+}
+
+/* === Aparição dos contadores === */
+.arcade-counters.show-stroke {
+  animation: lightStroke 0.7s forwards;
+}
+
+@keyframes lightStroke {
+  0% {
+    opacity: 0;
+    text-shadow: none;
+    filter: drop-shadow(0 0 20px #fff);
+  }
+  100% {
+    opacity: 1;
+    text-shadow: 0 0 20px #51ffe7, 0 0 40px #cf28ff;
+    filter: none;
+  }
 }


### PR DESCRIPTION
## Summary
- add RGB split entry animation for the calendar
- add light-stroke appearance for counters
- show both effects when leaving the start screen
- avoid auto launching celebration confetti on first load

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68458ed5849c832ca18f18586ccdb047