### PR TITLE
Fix calendar RGB split animation

### DIFF
--- a/style.css
+++ b/style.css
@@ -581,15 +581,16 @@ tr.dropdown[style*="display: none;"] {
   0% {
     opacity: 0;
     filter: drop-shadow(-8px 0 red) drop-shadow(8px 0 cyan);
-    transform: scale(0.95);
+    transform: translate(-50%, -50%) scale(0.95);
   }
   50% {
     filter: drop-shadow(4px 0 red) drop-shadow(-4px 0 cyan);
+    transform: translate(-50%, -50%) scale(0.98);
   }
   100% {
     opacity: 1;
     filter: none;
-    transform: none;
+    transform: translate(-50%, -50%);
   }
 }
 


### PR DESCRIPTION
## Summary
- keep calendar centered when applying RGB Split

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68459277dcb8832c8df2a6a143398fc1