### PR TITLE
Add year dropdown with current pointers

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,8 +53,8 @@
       <span class="counter-value" id="seqCount">0</span>
     </div>
     <div class="counter-box" id="feitos-counter">
-      <span class="counter-label">Hábitos<br>Feitos</span>
-      <span class="counter-value" id="doneCount">0</span>
+      <span class="counter-label">Prêmio<br>(mês atual)</span>
+      <span class="counter-value" id="rewardText"></span>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -201,6 +201,29 @@ html, body {
   image-rendering: pixelated;
 }
 
+/* === ANO === */
+.ano {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 3em;
+  color: var(--highlight);
+  margin: 40px 0 20px 0;
+  background: none !important;
+  border: none !important;
+  cursor: pointer;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  padding: 0 0 0 30px;
+  text-shadow: 0 0 24px #ffe379b6, 0 0 36px #31fcff99, 0 0 45px #31fcff77;
+  transition: color 0.17s cubic-bezier(.47,1.64,.41,.88);
+}
+.ano:hover { color: #51ffe7; text-shadow: 0 0 16px #51ffe788, 0 0 40px #ffe37944; }
+.ano:active { transform: scale(0.97); }
+.ano:not(.open) { opacity: 0.85; }
+.ano .arcade-arrow { position: absolute; left: 0; top: 0; }
+
 /* === MES === */
 .mes {
   font-family: 'Press Start 2P', monospace;
@@ -215,7 +238,7 @@ html, body {
   z-index: 10;
   text-shadow: 0 0 24px #ffe379b6, 0 0 36px #31fcff99, 0 0 45px #31fcff77;
   transition: color 0.17s cubic-bezier(.47,1.64,.41,.88);
-  padding: 0 0 0 38px;
+  padding: 0 0 0 30px;
 }
 .arcade-arrow {
   position: absolute;
@@ -229,19 +252,20 @@ html, body {
 
 .neon-arrow {
   position: absolute;
-  left: 0;
+  left: 4px;
   top: 50%;
   width: 0;
   height: 0;
   border-top: 12px solid transparent;
   border-bottom: 12px solid transparent;
-  border-left: 34px solid var(--mes-arrow);
+  border-left: 26px solid var(--mes-arrow);
   filter: drop-shadow(0 0 6px var(--mes-arrow)) drop-shadow(0 0 12px var(--mes-arrow));
   animation: arrow-move 0.8s infinite alternate;
   transform: translateY(-50%);
   pointer-events: none;
 }
 
+.ano-atual .neon-arrow,
 .mes-atual .neon-arrow,
 tr.main-row.current-day td:first-child::before {
   border-left-color: var(--mes-arrow-ativo);


### PR DESCRIPTION
## Summary
- group calendar by years with expandable dropdowns
- adjust neon pointer style and placement
- show current year/month pointers
- display next reward in counter sidebar

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_684598a94964832c9714e3917c132feb