### PR TITLE
Implement month auto-detection and calendar centering

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
       <span class="counter-value" id="seqCount">0</span>
     </div>
     <div class="counter-box" id="feitos-counter">
-      <span class="counter-label">Prêmio<br>(mês atual)</span>
+      <span class="counter-label">Prêmio<br><span id="currentMonth"></span></span>
       <span class="counter-value" id="rewardText"></span>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -281,6 +281,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       }
     });
     centerTodayDropdown();
+    adjustVerticalCentering();
   }
 
   function startApp() {
@@ -444,6 +445,14 @@ document.addEventListener("DOMContentLoaded", async function () {
     twemoji.parse(calendario, {folder: '72x72', ext: '.png'});
   }
   calendario.classList.add('loaded');
+  function adjustVerticalCentering() {
+    if (calendario.scrollHeight <= calendario.clientHeight + 5) {
+      calendario.classList.add('vertical-center');
+    } else {
+      calendario.classList.remove('vertical-center');
+    }
+  }
+  adjustVerticalCentering();
 
   // --- CONTINUAÇÃO ABAIXO ---
   // Dropdown lógica: abrir/fechar ANO, MÊS e DIAS
@@ -457,6 +466,8 @@ document.addEventListener("DOMContentLoaded", async function () {
   const mesAtual = today.getMonth() + 1;
   const anoAtual = today.getFullYear();
   const diaAtual = today.getDate();
+  const monthLabel = document.getElementById('currentMonth');
+  if (monthLabel) monthLabel.textContent = monthNames[mesAtual - 1];
 
   // Inicializa: todos fechados
   allAnoDivs.forEach((anoDiv, idx) => {
@@ -482,6 +493,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       drop.style.display = 'block';
       anoDiv.classList.add('open','ano-atual');
       anoDiv.querySelector('.arcade-arrow').innerHTML = `<span class="neon-arrow"></span>`;
+      adjustVerticalCentering();
     };
   });
 
@@ -547,6 +559,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
         }
       }
+      adjustVerticalCentering();
     };
   });
 
@@ -584,6 +597,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         dropRow.style.display = 'table-row';
         setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
         row.classList.add('expanded');
+        adjustVerticalCentering();
       };
     });
   });

--- a/style.css
+++ b/style.css
@@ -143,6 +143,11 @@ html, body {
   left: calc(1170px - 0.33cm);
   top: calc(55px - 2cm + 0.33cm);
 }
+#feitos-counter .counter-label {
+  font-size: 1.18em;
+  max-width: 100%;
+  white-space: normal;
+}
 
 /* ========== TELA PRINCIPAL CRT ========== */
 .arcade-screen-curve {
@@ -178,6 +183,9 @@ html, body {
   user-select: none;
   position: relative;
   opacity: 0;
+}
+#calendario.vertical-center {
+  justify-content: center;
 }
 
 #calendario {
@@ -222,7 +230,12 @@ html, body {
 .ano:hover { color: #51ffe7; text-shadow: 0 0 16px #51ffe788, 0 0 40px #ffe37944; }
 .ano:active { transform: scale(0.97); }
 .ano:not(.open) { opacity: 0.85; }
-.ano .arcade-arrow { position: absolute; left: 0; top: 0; }
+.ano .arcade-arrow {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  transform: translateY(-50%);
+}
 
 /* === MES === */
 .mes {
@@ -243,7 +256,9 @@ html, body {
 .arcade-arrow {
   position: absolute;
   left: 0;
-  top: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  pointer-events: none;
 }
 .mes .mes-label { z-index: 2; }
 .mes:hover { color: #51ffe7; text-shadow: 0 0 16px #51ffe788, 0 0 40px #ffe37944; }


### PR DESCRIPTION
## Summary
- auto-fill current month in reward counter
- center calendar vertically when contents are short
- tweak arrow positioning
- style reward counter label

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_68459cb50cf8832cb2cc5896e8e40c1b