### PR TITLE
Fix sticky header overlap

### DIFF
--- a/style.css
+++ b/style.css
@@ -238,9 +238,7 @@ html, body {
   transform: translateY(-50%);
 }
 .ano.open {
-  position: sticky;
-  top: 35px;
-  z-index: 15;
+  /* sticky behavior será controlado via JavaScript */
 }
 
 /* === MES === */
@@ -272,9 +270,7 @@ html, body {
 .mes:active { transform: scale(0.97); }
 .mes:not(.open) { opacity: 0.85; }
 .mes.open {
-  position: sticky;
-  top: 35px;
-  z-index: 15;
+  /* sticky behavior será controlado via JavaScript */
 }
 
 .neon-arrow {


### PR DESCRIPTION
## Summary
- remove CSS sticky styles from `.ano.open` and `.mes.open`
- delegate sticky behavior entirely to JavaScript logic

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e2373638832c9292a3bac2d60556