### PR TITLE
Fix sticky titles

### DIFF
--- a/script.js
+++ b/script.js
@@ -450,30 +450,20 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
   }
   function updateStickyOffsets() {
-    // Limpa estilos inline para anos, meses e dias
+    // Remove a classe sticky de todos os títulos/linhas
     document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row')
-      .forEach(el => {
-        el.style.position = '';
-        el.style.top = '';
-        el.style.zIndex = '';
-      });
+      .forEach(el => el.classList.remove('sticky'));
 
     const openDay = document.querySelector('#calendario tr.main-row.expanded');
     const openMonth = document.querySelector('#calendario .mes.open');
     const openYear = document.querySelector('#calendario .ano.open');
 
     if (openDay) {
-      openDay.style.position = 'sticky';
-      openDay.style.top = '35px';
-      openDay.style.zIndex = '15';
+      openDay.classList.add('sticky');
     } else if (openMonth) {
-      openMonth.style.position = 'sticky';
-      openMonth.style.top = '35px';
-      openMonth.style.zIndex = '15';
+      openMonth.classList.add('sticky');
     } else if (openYear) {
-      openYear.style.position = 'sticky';
-      openYear.style.top = '35px';
-      openYear.style.zIndex = '15';
+      openYear.classList.add('sticky');
     }
   }
 

--- a/style.css
+++ b/style.css
@@ -237,8 +237,14 @@ html, body {
   top: 50%;
   transform: translateY(-50%);
 }
+.sticky {
+  position: sticky;
+  top: 35px;
+  z-index: 15;
+}
+
 .ano.open {
-  /* sticky behavior será controlado via JavaScript */
+  /* sticky control via JavaScript */
 }
 
 /* === MES === */
@@ -270,7 +276,7 @@ html, body {
 .mes:active { transform: scale(0.97); }
 .mes:not(.open) { opacity: 0.85; }
 .mes.open {
-  /* sticky behavior será controlado via JavaScript */
+  /* sticky control via JavaScript */
 }
 
 .neon-arrow {


### PR DESCRIPTION
## Summary
- make sticky style a reusable `.sticky` class in CSS
- toggle `.sticky` class in JavaScript instead of inline styles

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845e4ab8204832c8a9ea612bf483d2a