### PR TITLE
Adjust sticky logic and layout

### DIFF
--- a/script.js
+++ b/script.js
@@ -450,21 +450,21 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
   }
   function updateStickyOffsets() {
-    // Remove a classe sticky de todos os títulos/linhas
-    document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row')
-      .forEach(el => el.classList.remove('sticky'));
-
-    const openDay = document.querySelector('#calendario tr.main-row.expanded');
-    const openMonth = document.querySelector('#calendario .mes.open');
-    const openYear = document.querySelector('#calendario .ano.open');
-
-    if (openDay) {
-      openDay.classList.add('sticky');
-    } else if (openMonth) {
-      openMonth.classList.add('sticky');
-    } else if (openYear) {
-      openYear.classList.add('sticky');
-    }
+    const threshold = 40;
+    const all = document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row');
+    all.forEach(el => {
+      const isOpen = el.classList.contains('open') || el.classList.contains('expanded');
+      if (isOpen) {
+        const rect = el.getBoundingClientRect();
+        if (rect.top <= threshold) {
+          el.classList.add('sticky');
+        } else {
+          el.classList.remove('sticky');
+        }
+      } else {
+        el.classList.remove('sticky');
+      }
+    });
   }
 
   function updateIndicators() {

--- a/style.css
+++ b/style.css
@@ -243,6 +243,10 @@ html, body {
   z-index: 15;
 }
 
+.mes.sticky {
+  background: var(--crt-dark) !important;
+}
+
 .ano.open {
   /* sticky control via JavaScript */
 }
@@ -403,7 +407,12 @@ tr.dropdown[style*="display: none;"] {
 }
 
 /* ==== HÁBITOS ==== */
-.habit-list { gap: 13px; margin: 14px 0; display: flex; flex-direction: column;}
+.habit-list {
+  gap: 13px;
+  margin: 6px 0;
+  display: flex;
+  flex-direction: column;
+}
 .habit-item {
   display: grid; grid-template-columns: 46px 1fr 38px; align-items: center;
   background: none !important;


### PR DESCRIPTION
## Summary
- make sticky logic depend on element position so that non-visible sections don't remove other sticky titles
- give sticky month headings a background color
- reduce day dropdown spacing

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6845e8627a44832c8b335a32ba9d7eea