### PR TITLE
Remove sticky behavior from calendar

### DIFF
--- a/script.js
+++ b/script.js
@@ -442,8 +442,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     twemoji.parse(calendario, {folder: '72x72', ext: '.png'});
   }
   calendario.classList.add('loaded');
-  calendario.addEventListener('scroll', handleStickyTitles);
-  handleStickyTitles();
+  // sticky titles disabled
   function adjustVerticalCentering() {
     if (calendario.scrollHeight <= calendario.clientHeight + 5) {
       calendario.classList.add('vertical-center');
@@ -451,27 +450,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       calendario.classList.remove('vertical-center');
     }
   }
-  function handleStickyTitles() {
-    const contRect = calendario.getBoundingClientRect();
-    const threshold = contRect.top + 35;
-    const candidates = document.querySelectorAll('#calendario .ano.open, #calendario .mes.open, #calendario tr.expanded');
-    let chosen = null;
-    let maxTop = -Infinity;
-    candidates.forEach(el => {
-      const rect = el.getBoundingClientRect();
-      if (rect.top <= threshold && rect.top > maxTop) {
-        chosen = el;
-        maxTop = rect.top;
-      }
-    });
-    candidates.forEach(el => {
-      if (el === chosen) {
-        el.classList.add('sticky');
-      } else {
-        el.classList.remove('sticky');
-      }
-    });
-  }
+  function handleStickyTitles() {}
 
   function updateIndicators() {
     document.querySelectorAll('#calendario .arcade-arrow').forEach(a => a.innerHTML = '');

--- a/style.css
+++ b/style.css
@@ -237,15 +237,6 @@ html, body {
   top: 50%;
   transform: translateY(-50%);
 }
-.sticky {
-  position: sticky;
-  top: 35px;
-  z-index: 15;
-}
-
-.mes.sticky {
-  background: var(--crt-dark) !important;
-}
 
 .ano.open {
   /* sticky control via JavaScript */


### PR DESCRIPTION
## Summary
- remove `.sticky` rules from CSS
- disable sticky handling in script

## Testing
- `node --check script.js`

------
https://chatgpt.com/codex/tasks/task_e_6845ef67337c832c9d7900520ff510ca