### PR TITLE
Implement sticky dropdown titles

### DIFF
--- a/script.js
+++ b/script.js
@@ -450,7 +450,29 @@ document.addEventListener("DOMContentLoaded", async function () {
       calendario.classList.remove('vertical-center');
     }
   }
-  function handleStickyTitles() {}
+  function handleStickyTitles() {
+    const cal = document.getElementById('calendario');
+    if (!cal) return;
+    document.querySelectorAll('#calendario .ano, #calendario .mes')
+      .forEach(el => el.classList.remove('sticky-title'));
+
+    const openMonth = document.querySelector('#calendario .mes.open');
+    if (openMonth) {
+      const drop = openMonth.nextElementSibling;
+      if (drop && drop.scrollHeight > cal.clientHeight - openMonth.offsetHeight) {
+        openMonth.classList.add('sticky-title');
+        return;
+      }
+    }
+
+    const openYear = document.querySelector('#calendario .ano.open');
+    if (openYear) {
+      const drop = openYear.nextElementSibling;
+      if (drop && drop.scrollHeight > cal.clientHeight - openYear.offsetHeight) {
+        openYear.classList.add('sticky-title');
+      }
+    }
+  }
 
   function updateIndicators() {
     document.querySelectorAll('#calendario .arcade-arrow').forEach(a => a.innerHTML = '');

--- a/style.css
+++ b/style.css
@@ -242,6 +242,16 @@ html, body {
   /* sticky control via JavaScript */
 }
 
+/* sticky header when dropdown exceeds container */
+.ano.sticky-title,
+.mes.sticky-title {
+  position: sticky;
+  top: 0;
+  margin-top: 0;
+  background: rgba(0, 0, 0, 0.6);
+  z-index: 20;
+}
+
 /* === MES === */
 .mes {
   font-family: 'Press Start 2P', monospace;


### PR DESCRIPTION
## Summary
- implement sticky header behavior for calendar dropdowns
- add `sticky-title` CSS class for month/year headers
- update `handleStickyTitles` in `script.js` to manage sticky state

## Testing
- `git status --short`
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6845fe809ae4832ca2ed720b3b68438c