### PR TITLE
Adjust calendar mask for sticky titles

### DIFF
--- a/script.js
+++ b/script.js
@@ -455,6 +455,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!cal) return;
     document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row')
       .forEach(el => el.classList.remove('sticky-title'));
+    cal.style.setProperty('--top-mask-stop', '35px');
 
     const stickyOffset = 40;
 
@@ -463,6 +464,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openDay.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openDay.offsetHeight - stickyOffset) {
         openDay.classList.add('sticky-title');
+        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
         return;
       }
     }
@@ -472,6 +474,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openMonth.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openMonth.offsetHeight - stickyOffset) {
         openMonth.classList.add('sticky-title');
+        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
         return;
       }
     }
@@ -481,6 +484,7 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openYear.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openYear.offsetHeight - stickyOffset) {
         openYear.classList.add('sticky-title');
+        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -189,8 +189,10 @@ html, body {
 }
 
 #calendario {
-  -webkit-mask-image: linear-gradient(to bottom, transparent, black 35px, black calc(100% - 35px), transparent);
-          mask-image: linear-gradient(to bottom, transparent, black 35px, black calc(100% - 35px), transparent);
+  --top-mask-stop: 35px;
+  --bottom-mask-stop: 35px;
+  -webkit-mask-image: linear-gradient(to bottom, transparent, black var(--top-mask-stop), black calc(100% - var(--bottom-mask-stop)), transparent);
+          mask-image: linear-gradient(to bottom, transparent, black var(--top-mask-stop), black calc(100% - var(--bottom-mask-stop)), transparent);
   -webkit-mask-size: 100% 100%;
           mask-size: 100% 100%;
 }


### PR DESCRIPTION
## Summary
- add mask CSS variables for calendar
- update sticky title logic to modify mask

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68460d4a05d8832c8384356e464f9883