### PR TITLE
Adjust sticky gradient and counter label size

### DIFF
--- a/script.js
+++ b/script.js
@@ -455,7 +455,8 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!cal) return;
     document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row')
       .forEach(el => el.classList.remove('sticky-title'));
-    cal.style.setProperty('--top-mask-stop', '35px');
+    cal.style.setProperty('--top-mask-start', '0px');
+    cal.style.setProperty('--top-fade-size', '35px');
 
     const stickyOffset = 40;
 
@@ -464,7 +465,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openDay.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openDay.offsetHeight - stickyOffset) {
         openDay.classList.add('sticky-title');
-        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
+        const start = stickyOffset + openDay.offsetHeight;
+        cal.style.setProperty('--top-mask-start', start + 'px');
+        cal.style.setProperty('--top-fade-size', '1cm');
         return;
       }
     }
@@ -474,7 +477,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openMonth.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openMonth.offsetHeight - stickyOffset) {
         openMonth.classList.add('sticky-title');
-        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
+        const start = stickyOffset + openMonth.offsetHeight;
+        cal.style.setProperty('--top-mask-start', start + 'px');
+        cal.style.setProperty('--top-fade-size', '1cm');
         return;
       }
     }
@@ -484,7 +489,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openYear.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openYear.offsetHeight - stickyOffset) {
         openYear.classList.add('sticky-title');
-        cal.style.setProperty('--top-mask-stop', stickyOffset + 'px');
+        const start = stickyOffset + openYear.offsetHeight;
+        cal.style.setProperty('--top-mask-start', start + 'px');
+        cal.style.setProperty('--top-fade-size', '1cm');
       }
     }
   }

--- a/style.css
+++ b/style.css
@@ -148,6 +148,9 @@ html, body {
   max-width: 100%;
   white-space: normal;
 }
+#feitos-counter .counter-value {
+  font-size: 1.18em;
+}
 
 /* ========== TELA PRINCIPAL CRT ========== */
 .arcade-screen-curve {
@@ -189,10 +192,25 @@ html, body {
 }
 
 #calendario {
-  --top-mask-stop: 35px;
+  --top-mask-start: 0px;
+  --top-fade-size: 35px;
   --bottom-mask-stop: 35px;
-  -webkit-mask-image: linear-gradient(to bottom, transparent, black var(--top-mask-stop), black calc(100% - var(--bottom-mask-stop)), transparent);
-          mask-image: linear-gradient(to bottom, transparent, black var(--top-mask-stop), black calc(100% - var(--bottom-mask-stop)), transparent);
+  -webkit-mask-image: linear-gradient(
+      to bottom,
+      black 0,
+      black var(--top-mask-start),
+      transparent calc(var(--top-mask-start) + var(--top-fade-size)),
+      black calc(100% - var(--bottom-mask-stop)),
+      transparent
+  );
+          mask-image: linear-gradient(
+      to bottom,
+      black 0,
+      black var(--top-mask-start),
+      transparent calc(var(--top-mask-start) + var(--top-fade-size)),
+      black calc(100% - var(--bottom-mask-stop)),
+      transparent
+  );
   -webkit-mask-size: 100% 100%;
           mask-size: 100% 100%;
 }


### PR DESCRIPTION
## Summary
- refine gradient masking on #calendario so fade begins below sticky title
- make reward description font size match its label

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68460fb36334832ca298f8010a3393ca