### PR TITLE
Fix sticky title transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -269,7 +269,7 @@ tr.main-row.sticky-title {
   position: sticky;
   top: 40px;
   margin-top: 0;
-  background: rgba(0, 0, 0, 0.6);
+  background: var(--crt-dark);
   z-index: 20;
 }
 


### PR DESCRIPTION
## Summary
- ensure sticky header backgrounds stay solid

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6846164096a0832caea487c1faf442a9