### PR TITLE
Implement sticky title overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@
       <div class="start-title">Pronto para tomar o controle da sua vida?</div>
       <div class="press-start">Press Start</div>
     </div>
+    <div id="sticky-title-overlay" aria-hidden="true"></div>
     <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;"></div>
   </div>
 

--- a/script.js
+++ b/script.js
@@ -452,9 +452,17 @@ document.addEventListener("DOMContentLoaded", async function () {
   }
   function handleStickyTitles() {
     const cal = document.getElementById('calendario');
-    if (!cal) return;
+    const overlay = document.getElementById('sticky-title-overlay');
+    if (!cal || !overlay) return;
     document.querySelectorAll('#calendario .ano, #calendario .mes, #calendario tr.main-row')
-      .forEach(el => el.classList.remove('sticky-title'));
+      .forEach(el => {
+        el.classList.remove('sticky-title');
+        el.style.visibility = '';
+        const drop = el.nextElementSibling;
+        if (drop) drop.style.marginTop = '';
+      });
+    overlay.innerHTML = '';
+    overlay.style.display = 'none';
     cal.style.setProperty('--top-mask-start', '0px');
     cal.style.setProperty('--top-fade-size', '35px');
 
@@ -465,6 +473,16 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openDay.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openDay.offsetHeight - stickyOffset) {
         openDay.classList.add('sticky-title');
+        const clone = openDay.cloneNode(true);
+        clone.removeAttribute('id');
+        clone.querySelectorAll('[id]').forEach(n => n.removeAttribute('id'));
+        const table = document.createElement('table');
+        const tbody = document.createElement('tbody');
+        tbody.appendChild(clone);
+        table.appendChild(tbody);
+        overlay.appendChild(table);
+        overlay.style.display = 'block';
+        drop.style.marginTop = '16px';
         const start = stickyOffset + openDay.offsetHeight;
         cal.style.setProperty('--top-mask-start', start + 'px');
         cal.style.setProperty('--top-fade-size', '1cm');
@@ -477,6 +495,11 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openMonth.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openMonth.offsetHeight - stickyOffset) {
         openMonth.classList.add('sticky-title');
+        const clone = openMonth.cloneNode(true);
+        clone.removeAttribute('id');
+        overlay.appendChild(clone);
+        overlay.style.display = 'block';
+        drop.style.marginTop = '16px';
         const start = stickyOffset + openMonth.offsetHeight;
         cal.style.setProperty('--top-mask-start', start + 'px');
         cal.style.setProperty('--top-fade-size', '1cm');
@@ -489,6 +512,11 @@ document.addEventListener("DOMContentLoaded", async function () {
       const drop = openYear.nextElementSibling;
       if (drop && drop.scrollHeight > cal.clientHeight - openYear.offsetHeight - stickyOffset) {
         openYear.classList.add('sticky-title');
+        const clone = openYear.cloneNode(true);
+        clone.removeAttribute('id');
+        overlay.appendChild(clone);
+        overlay.style.display = 'block';
+        drop.style.marginTop = '16px';
         const start = stickyOffset + openYear.offsetHeight;
         cal.style.setProperty('--top-mask-start', start + 'px');
         cal.style.setProperty('--top-fade-size', '1cm');

--- a/style.css
+++ b/style.css
@@ -269,8 +269,20 @@ tr.main-row.sticky-title {
   position: sticky;
   top: 40px;
   margin-top: 0;
-  background: var(--crt-dark);
+  background: none !important;
+  visibility: hidden;
   z-index: 20;
+}
+
+/* overlay para titulo sticky fora do mascaramento */
+#sticky-title-overlay {
+  position: absolute;
+  top: 40px;
+  left: 0;
+  width: 100%;
+  display: none;
+  z-index: 25;
+  pointer-events: none;
 }
 
 /* === MES === */


### PR DESCRIPTION
## Summary
- add overlay container for sticky titles
- keep sticky titles fully visible by cloning into overlay
- ensure sticky titles retain transparent backgrounds
- add spacing between sticky headers and dropdown content

## Testing
- `node --version`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_684618c41898832c980d74f35b48d23c