### PR TITLE
Fix calendar scroll bug

### DIFF
--- a/script.js
+++ b/script.js
@@ -488,7 +488,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         table.appendChild(tbody);
         overlay.appendChild(table);
         overlay.style.display = 'block';
-        overlay.style.pointerEvents = 'auto';
+        overlay.style.pointerEvents = 'none';
         table.addEventListener('click', () => openDay.click());
         drop.style.marginTop = (openDay.offsetHeight + spacing) + 'px';
         const start = stickyOffset + openDay.offsetHeight;
@@ -510,7 +510,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         clone.classList.remove('sticky-title');
         overlay.appendChild(clone);
         overlay.style.display = 'block';
-        overlay.style.pointerEvents = 'auto';
+        overlay.style.pointerEvents = 'none';
         clone.addEventListener('click', () => openMonth.click());
         drop.style.marginTop = (openMonth.offsetHeight + spacing) + 'px';
         const start = stickyOffset + openMonth.offsetHeight;
@@ -532,7 +532,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         clone.classList.remove('sticky-title');
         overlay.appendChild(clone);
         overlay.style.display = 'block';
-        overlay.style.pointerEvents = 'auto';
+        overlay.style.pointerEvents = 'none';
         clone.addEventListener('click', () => openYear.click());
         drop.style.marginTop = (openYear.offsetHeight + spacing) + 'px';
         const start = stickyOffset + openYear.offsetHeight;


### PR DESCRIPTION
## Summary
- keep sticky title overlay from intercepting mouse events

## Testing
- `python3 -m http.server 8000 >/tmp/http.log 2>&1 &`
- `curl -I http://localhost:8000/index.html`

------
https://chatgpt.com/codex/tasks/task_e_6846d7238f08832c83669ea47c6d2c43