### PR TITLE
Adjust calendar container size and fade

### DIFF
--- a/style.css
+++ b/style.css
@@ -181,7 +181,7 @@ html, body {
 
 /* ========== CALENDÁRIO E MES ========== */
 #calendario {
-  position: absolute; left: 50%; top: 50%; width: 96%; height: 105%;
+  position: absolute; left: 50%; top: 50%; width: 92%; height: 96%;
   max-width: 100%; max-height: 99%; min-width: 120px; min-height: 70px;
   transform: translate(-50%, -50%);
   display: flex; flex-direction: column;
@@ -202,8 +202,8 @@ html, body {
 
 #calendario {
   --top-mask-start: 0px;
-  --top-fade-size: 35px;
-  --bottom-mask-stop: 35px;
+  --top-fade-size: 50px;
+  --bottom-mask-stop: 50px;
   -webkit-mask-image: linear-gradient(
       to bottom,
       transparent 0,


### PR DESCRIPTION
## Summary
- tweak calendar container size
- smooth fade in mask to hide content earlier

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6849d16e7cb0832cbe887eca37ef60fb