### PR TITLE
Add progress bar for monthly reward counter

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,7 @@
       </div>
       <div class="counter-box" id="feitos-counter">
         <span class="counter-label">Prêmio<br><span id="currentMonth"></span></span>
+        <div class="counter-progress-bg"><div class="counter-progress" id="current-reward-bar"></div></div>
         <span class="counter-value" id="rewardText"></span>
       </div>
     </div>

--- a/script.js
+++ b/script.js
@@ -726,9 +726,11 @@ document.addEventListener("DOMContentLoaded", async function () {
   function updateRewardProgress(month, year, totalDias, diasCompletos, skipCelebrate = false) {
     const pct = diasCompletos / totalDias;
     const bar = document.getElementById(`reward-bar-${month}-${year}`);
+    const counterBar = document.getElementById("current-reward-bar");
     const unlocked = document.getElementById(`reward-unlocked-${month}-${year}`);
     if (bar) {
       bar.style.width = (pct * 100) + "%";
+      if (counterBar && Number(month) === mesAtual && Number(year) === anoAtual) counterBar.style.width = (pct * 100) + "%";
       const celebrateKey = `reward-celebrated-${month}-${year}`;
       const already = localStorage.getItem(celebrateKey) === 'true';
       if (pct === 1) {

--- a/style.css
+++ b/style.css
@@ -166,9 +166,29 @@ html, body {
   font-size: 1.18em;
   max-width: 100%;
   white-space: normal;
+
+  margin-bottom: 6px;
 }
 #feitos-counter .counter-value {
   font-size: 1.18em;
+}
+
+#feitos-counter .counter-progress-bg {
+  width: calc(100% - 1cm);
+  height: 12px;
+  background: rgba(0, 0, 0, 0.05);
+  border-radius: 6px;
+  overflow: hidden;
+  margin: 4px 0 6px 0;
+  box-shadow: 0 0 12px #51ffe799, 0 0 5px #cf28ff33;
+}
+#feitos-counter .counter-progress {
+  height: 100%;
+  width: 0;
+  background: linear-gradient(90deg, #cf28ff 10%, #51ffe7 90%);
+  border-radius: inherit;
+  transition: width 0.45s cubic-bezier(.6,1.2,.16,1.08);
+  box-shadow: 0 0 10px #cf28ff88, 0 0 5px #51ffe799;
 }
 
 /* ========== TELA PRINCIPAL CRT ========== */


### PR DESCRIPTION
## Summary
- show a progress bar for the current month's reward counter
- style the new bar with a slimmer width and neon look
- sync the counter bar with reward progress in script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684c8e24b138832c88eabd583c63f6b5