### PR TITLE
Add life hearts feature

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,6 +62,11 @@
         <div class="press-start">Press Start</div>
       </div>
       <div id="sticky-title-overlay" aria-hidden="true"></div>
+      <div id="life-container" style="display:none;">
+        <span class="life-heart">❤️</span>
+        <span class="life-heart">❤️</span>
+        <span class="life-heart">❤️</span>
+      </div>
       <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;"></div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -249,6 +249,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const startScreen = document.getElementById('start-screen');
   const calendarioEl = document.getElementById('calendario');
   const countersEl = document.querySelector('.arcade-counters');
+  const lifeContainer = document.getElementById('life-container');
   const videoWrapper = document.getElementById('video-wrapper');
 
   function resizeWrapper() {
@@ -335,6 +336,11 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (countersEl) {
         countersEl.style.display = '';
         countersEl.classList.add('show-stroke');
+      }
+      if (lifeContainer) {
+        lifeContainer.style.display = '';
+        lifeContainer.classList.add('show');
+        updateLivesDisplay();
       }
       openCurrentMonthDay();
     }, 800);
@@ -802,6 +808,30 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (reward) {
       document.getElementById('rewardText').textContent = reward.label;
     }
+    updateLivesDisplay();
+  }
+
+  function updateLivesDisplay() {
+    if (!lifeContainer) return;
+    const hearts = lifeContainer.querySelectorAll('.life-heart');
+    const today = new Date();
+    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const yesterday = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1);
+    let lost = 0;
+    for (const dia of dados) {
+      const rowDate = new Date(dia.ano, dia.mes - 1, dia.diaDoMes);
+      if (rowDate < startOfMonth) continue;
+      if (rowDate > yesterday) break;
+      const row = document.getElementById(`mainrow-${dia.id}`);
+      if (!row || !row.classList.contains('day-complete')) {
+        lost++;
+        if (lost >= 3) break;
+      }
+    }
+    const remaining = Math.max(0, 3 - lost);
+    hearts.forEach((h, idx) => {
+      h.style.visibility = idx < remaining ? 'visible' : 'hidden';
+    });
   }
 
   // Checkbox lógica

--- a/style.css
+++ b/style.css
@@ -324,6 +324,28 @@ tr.main-row.sticky-title {
   pointer-events: none;
 }
 
+/* === LIFE HEARTS === */
+#life-container {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 8px;
+  font-size: 2em;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 26;
+}
+#life-container.show {
+  opacity: 1;
+}
+
+.life-heart {
+  filter: drop-shadow(0 0 8px #ff6be7aa);
+}
+
 /* === MES === */
 .mes {
   font-family: 'Press Start 2P', monospace;


### PR DESCRIPTION
## Summary
- add life-hearts container in the calendar area
- style life hearts and fade in animation
- compute remaining lives from incomplete days
- show hearts when starting the app

## Testing
- `tidy -errors index.html` *(fails: command not found)*
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_684c9227ecd0832c82e75f2b5eadd516