### PR TITLE
Adjust calendar size and add lives label

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,12 +62,14 @@
         <div class="press-start">Press Start</div>
       </div>
       <div id="sticky-title-overlay" aria-hidden="true"></div>
-      <div id="life-container" style="display:none;">
-        <span class="life-heart">❤️</span>
-        <span class="life-heart">❤️</span>
-        <span class="life-heart">❤️</span>
+      <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;">
+        <div id="life-container" style="display:none;">
+          <span class="life-label">Vidas</span>
+          <span class="life-heart">❤️</span>
+          <span class="life-heart">❤️</span>
+          <span class="life-heart">❤️</span>
+        </div>
       </div>
-      <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;"></div>
     </div>
   </div>
 

--- a/style.css
+++ b/style.css
@@ -211,12 +211,13 @@ html, body {
 
 /* ========== CALENDÁRIO E MES ========== */
 #calendario {
-  position: absolute; left: 50%; top: 50%; width: 92%; height: 96%;
+  position: absolute; left: 50%; top: 50%; width: 88%; height: 92%;
   max-width: 100%; max-height: 99%; min-width: 120px; min-height: 70px;
   transform: translate(-50%, -50%);
   display: flex; flex-direction: column;
   color: #ffe379;
   font-family: 'Press Start 2P', monospace;
+  font-size: 0.9em;
   padding: 0 1vw 0 1vw;
   overflow-y: auto;
   box-sizing: border-box;
@@ -328,13 +329,15 @@ tr.main-row.sticky-title {
 #life-container {
   position: absolute;
   top: -30px;
-  left: 50%;
-  transform: translateX(-50%);
+  left: 0;
+  transform: none;
   display: flex;
+  align-items: center;
   gap: 8px;
   font-size: 2em;
   pointer-events: none;
   opacity: 0;
+  overflow: visible;
   transition: opacity 0.3s ease;
   z-index: 26;
 }
@@ -345,6 +348,13 @@ tr.main-row.sticky-title {
 .life-heart {
   filter: drop-shadow(0 0 8px #ff6be7aa);
   animation: heart-glow 1.6s ease-in-out infinite alternate;
+}
+
+.life-label {
+  margin-right: 6px;
+  font-size: 0.6em;
+  color: var(--highlight);
+  text-shadow: 0 0 8px #ff6be7aa;
 }
 
 @keyframes heart-glow {
@@ -659,7 +669,7 @@ tr.dropdown[style*="display: none;"] {
 }
 @media (max-width: 650px) {
   .arcade-screen-curve { width: 99vw; min-width: 40px; left: 50%; top: 54%; border-radius: 28px 22px 28px 28px/32px 38px 31px 27px;}
-  #calendario { font-size: 0.77em; padding: 0 1vw 0 1vw;}
+  #calendario { font-size: 0.7em; padding: 0 1vw 0 1vw;}
   .arcade-counters {
     width: 1920px;
     height: 1080px;


### PR DESCRIPTION
## Summary
- decrease calendar width, height and font size
- move life container inside calendar and show "Vidas" label
- position hearts at top-left with overflow
- tweak mobile calendar font

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684ca715ac60832ca59d3db20fda7f84