### PR TITLE
Fix centering of life indicator

### DIFF
--- a/script.js
+++ b/script.js
@@ -257,9 +257,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!lifeContainer || !calendarioEl) return;
     const calRect = calendarioEl.getBoundingClientRect();
     const parentRect = lifeContainer.parentElement.getBoundingClientRect();
-    const label = lifeContainer.querySelector('.life-label');
-    const labelW = label ? label.getBoundingClientRect().width : 0;
-    const left = calRect.left + calRect.width / 2 - parentRect.left - labelW / 2;
+    const left = calRect.left + calRect.width / 2 - parentRect.left;
     lifeContainer.style.left = `${left}px`;
   }
 


### PR DESCRIPTION
## Summary
- adjust positioning logic of the life counter so that label and hearts stay centered together

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c6175474c832c9fb2927d7a1fc7c2