### PR TITLE
Add diary entry workflow for gratitude habit

### DIFF
--- a/style.css
+++ b/style.css
@@ -565,6 +565,263 @@ tr.dropdown[style*="display: none;"] {
   filter: drop-shadow(0 0 3px var(--highlight));
 }
 
+.habit-item.diary-habit {
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.habit-item.diary-habit.diary-filled {
+  border-color: rgba(255, 227, 121, 0.85);
+  box-shadow: 0 0 18px rgba(255, 227, 121, 0.35), 0 0 10px rgba(81, 255, 231, 0.25);
+}
+
+.habit-item.diary-habit.diary-filled::after {
+  content: 'SALVO';
+  position: absolute;
+  top: -12px;
+  right: 18px;
+  background: linear-gradient(90deg, rgba(255, 227, 121, 0.95), rgba(81, 255, 231, 0.9));
+  color: #001130;
+  font-size: 0.48em;
+  letter-spacing: 0.18em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  box-shadow: 0 0 12px rgba(255, 227, 121, 0.45);
+}
+
+.diary-editor {
+  margin-top: 22px;
+  padding: 20px 22px 22px 22px;
+  border-radius: 20px;
+  border: 1px solid rgba(81, 255, 231, 0.55);
+  background: linear-gradient(135deg, rgba(0, 17, 43, 0.82), rgba(0, 28, 60, 0.78));
+  box-shadow: 0 0 22px rgba(81, 255, 231, 0.15), inset 0 0 16px rgba(0, 0, 0, 0.35);
+}
+
+.diary-textarea {
+  width: 100%;
+  min-height: 150px;
+  resize: vertical;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.72em;
+  line-height: 1.7;
+  letter-spacing: 0.03em;
+  color: var(--highlight);
+  background: rgba(0, 12, 34, 0.82);
+  border: 2px solid rgba(81, 255, 231, 0.65);
+  border-radius: 14px;
+  padding: 16px 18px;
+  box-shadow: inset 0 0 18px rgba(0, 0, 0, 0.45), 0 0 16px rgba(81, 255, 231, 0.12);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  color-scheme: dark;
+}
+
+.diary-textarea::placeholder {
+  color: rgba(103, 234, 255, 0.55);
+}
+
+.diary-textarea:focus {
+  outline: none;
+  border-color: var(--highlight);
+  box-shadow: inset 0 0 20px rgba(0, 0, 0, 0.38), 0 0 22px rgba(255, 227, 121, 0.35);
+}
+
+.diary-actions {
+  margin-top: 16px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  justify-content: flex-end;
+}
+
+.diary-save,
+.diary-cancel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.66em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 14px;
+  padding: 12px 22px;
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, filter 0.18s ease;
+}
+
+.diary-save {
+  border: 2px solid rgba(255, 227, 121, 0.95);
+  background: linear-gradient(90deg, rgba(255, 227, 121, 0.92), rgba(81, 255, 231, 0.9));
+  color: #001130;
+  box-shadow: 0 0 18px rgba(255, 227, 121, 0.45), 0 0 20px rgba(81, 255, 231, 0.3);
+}
+
+.diary-save:hover:not(:disabled) {
+  transform: translateY(-2px);
+  box-shadow: 0 0 24px rgba(255, 227, 121, 0.55), 0 0 26px rgba(81, 255, 231, 0.35);
+}
+
+.diary-save:active:not(:disabled) {
+  transform: translateY(1px) scale(0.98);
+}
+
+.diary-save:disabled {
+  opacity: 0.7;
+  cursor: not-allowed;
+  box-shadow: none;
+}
+
+.diary-cancel {
+  border: 2px solid rgba(103, 234, 255, 0.6);
+  background: rgba(0, 12, 34, 0.7);
+  color: var(--highlight);
+  box-shadow: 0 0 16px rgba(81, 255, 231, 0.22);
+}
+
+.diary-cancel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 22px rgba(81, 255, 231, 0.32);
+}
+
+.diary-cancel:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.diary-log-button-wrapper {
+  margin: 32px 0 20px 0;
+  display: flex;
+  justify-content: center;
+}
+
+.diary-log-button {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.78em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 14px 28px;
+  border-radius: 20px;
+  border: 2px solid var(--neon);
+  background: rgba(0, 18, 46, 0.72);
+  color: var(--highlight);
+  box-shadow: 0 0 22px rgba(81, 255, 231, 0.32), 0 0 28px rgba(207, 40, 255, 0.28);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.diary-log-button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 26px rgba(81, 255, 231, 0.45), 0 0 32px rgba(207, 40, 255, 0.35);
+}
+
+.diary-log-button:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.diary-log-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.72);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 120;
+  padding: 36px 18px;
+  backdrop-filter: blur(6px);
+}
+
+.diary-log-panel.open {
+  display: flex;
+}
+
+.diary-log-content {
+  width: min(720px, 92vw);
+  max-height: 84vh;
+  background: linear-gradient(135deg, rgba(0, 21, 48, 0.92), rgba(18, 10, 40, 0.94));
+  border: 2px solid rgba(81, 255, 231, 0.8);
+  border-radius: 28px;
+  box-shadow: 0 0 40px rgba(81, 255, 231, 0.35), 0 0 60px rgba(207, 40, 255, 0.28);
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+}
+
+.diary-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.diary-log-title {
+  color: var(--highlight);
+  font-size: 0.96em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(255, 227, 121, 0.6), 0 0 28px rgba(81, 255, 231, 0.35);
+}
+
+.diary-log-close {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.6em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 14px;
+  padding: 10px 18px;
+  border: 2px solid rgba(255, 227, 121, 0.8);
+  background: rgba(0, 12, 34, 0.7);
+  color: var(--highlight);
+  cursor: pointer;
+  box-shadow: 0 0 18px rgba(255, 227, 121, 0.35);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
+.diary-log-close:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 22px rgba(255, 227, 121, 0.45);
+}
+
+.diary-log-close:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.diary-log-list {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+  gap: 14px;
+  display: flex;
+  flex-direction: column;
+}
+
+.diary-log-item {
+  background: rgba(0, 12, 36, 0.78);
+  border: 1px solid rgba(81, 255, 231, 0.5);
+  border-radius: 18px;
+  padding: 16px 18px 18px 18px;
+  box-shadow: 0 0 16px rgba(81, 255, 231, 0.2);
+}
+
+.diary-log-date {
+  color: var(--highlight);
+  font-size: 0.78em;
+  letter-spacing: 0.06em;
+  margin-bottom: 12px;
+  text-transform: uppercase;
+}
+
+.diary-log-text {
+  color: var(--white);
+  font-size: 0.72em;
+  line-height: 1.6;
+  letter-spacing: 0.03em;
+  word-break: break-word;
+}
+
+.diary-empty {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.72em;
+  text-align: center;
+  color: rgba(103, 234, 255, 0.7);
+  margin: 60px 0 30px 0;
+}
+
 /* ==== PRÊMIOS ==== */
 .reward-card {
   display: flex; flex-direction: column; align-items: center; justify-content: center;


### PR DESCRIPTION
## Summary
- add Firebase diary retrieval, persistence helpers and HTML rendering hooks for the "Diário e gratidão" habit
- show a diary editor when the cyclical habit is clicked and wire save/cancel actions that sync entries with Firestore and update progress automatically
- create a themed diary log overlay and styling for the editor, saved state indicator, and access button

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0543be8ec832cbb737bec665ad06e