### PR TITLE
Fix calendar headers and dropdown alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -619,9 +619,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       <div class="mes-dropdown" id="dropdown-mes-${mesNum}-${ano}"><table>
         <thead>
           <tr>
-            <th>Data</th>
-            <th>Hábitos Diários</th>
-            <th>Hábito Cíclico</th>
+            <th class="col-date">Data</th>
+            <th class="col-daily">Hábitos Diários</th>
+            <th class="col-cyclic">Hábito Cíclico</th>
           </tr>
         </thead>
         <tbody>`;
@@ -651,9 +651,9 @@ document.addEventListener("DOMContentLoaded", async function () {
             </div>` : '';
       html += `
         <tr class="main-row arcade-clicavel" data-dropdown="${dia.id}" id="mainrow-${dia.id}">
-          <td class="progress-text gold">${dia.data}</td>
-          <td class="progress-text gold">${habitosCellText}</td>
-          <td class="progress-text gold">${dia.ciclico}</td>
+          <td class="progress-text gold col-date">${dia.data}</td>
+          <td class="progress-text gold col-daily">${habitosCellText}</td>
+          <td class="progress-text gold col-cyclic">${dia.ciclico}</td>
         </tr>
         <tr class="dropdown" id="dropdown-${dia.id}" style="display: none;">
           <td colspan="3">

--- a/style.css
+++ b/style.css
@@ -455,6 +455,26 @@ th, td {
   border: none !important;
 }
 
+#calendario table th.col-date,
+#calendario table td.col-date {
+  width: 20%;
+  min-width: 120px;
+}
+
+#calendario table th.col-daily,
+#calendario table td.col-daily {
+  width: 50%;
+}
+
+#calendario table th.col-cyclic,
+#calendario table td.col-cyclic {
+  width: 30%;
+}
+
+#calendario .mes-dropdown tr.dropdown td {
+  padding: 18px 18px 18px 34px;
+}
+
 /* ==== Linhas principais === */
 tr.main-row {
   cursor: pointer;


### PR DESCRIPTION
## Summary
- assign dedicated classes to the calendar headers and rows so each column stays aligned
- enforce column widths in CSS to keep the Data, Hábitos Diários, and Hábito Cíclico labels above the right columns
- add padding to the dropdown cell so the habit list content lines up with the main row

## Testing
- not run (frontend changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d06e83e7f8832c9813e238c30f92ab