### PR TITLE
Fix calendar column alignment

### DIFF
--- a/script.js
+++ b/script.js
@@ -477,7 +477,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           const d = parseInt(dateCell.innerText.split('/')[0]);
           if (d === diaAtual) {
             row.classList.add('current-day', 'expanded');
-            dropRow.style.display = 'table-row';
+            dropRow.style.display = 'block';
             setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
           }
         });
@@ -1141,7 +1141,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         const mainRow = dropdown.querySelectorAll('.main-row')[idxDia];
         const dropRow = dropdown.querySelectorAll('.dropdown')[idxDia];
         mainRow.classList.add('expanded');
-        dropRow.style.display = 'table-row';
+        dropRow.style.display = 'block';
         setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
       }
     }
@@ -1186,7 +1186,7 @@ document.addEventListener("DOMContentLoaded", async function () {
           return;
         }
         // Abre clicado
-        dropRow.style.display = 'table-row';
+        dropRow.style.display = 'block';
         setTimeout(() => dropRow.classList.add('arcade-drop-show'), 5);
         row.classList.add('expanded');
         adjustVerticalCentering();

--- a/style.css
+++ b/style.css
@@ -459,35 +459,40 @@ th, td {
   width: 100%;
   margin-left: auto;
   margin-right: auto;
-  table-layout: fixed;
+  border-collapse: separate;
 }
 
-#calendario .mes-dropdown table col.col-date {
-  width: 22%;
+#calendario .mes-dropdown table colgroup {
+  display: none;
 }
 
-#calendario .mes-dropdown table col.col-daily {
-  width: 46%;
+#calendario .mes-dropdown table thead,
+#calendario .mes-dropdown table tbody {
+  display: block;
+  width: 100%;
 }
 
-#calendario .mes-dropdown table col.col-cyclic {
-  width: 32%;
+#calendario .mes-dropdown table thead tr,
+#calendario .mes-dropdown table tbody tr.main-row {
+  display: grid;
+  grid-template-columns: minmax(120px, 0.22fr) minmax(200px, 0.46fr) minmax(140px, 0.32fr);
+  align-items: center;
+  width: 100%;
 }
 
-#calendario table th.col-date,
-#calendario table td.col-date {
-  width: 22%;
-  min-width: 120px;
+#calendario .mes-dropdown table thead th,
+#calendario .mes-dropdown table tbody tr.main-row > td {
+  display: block;
+  width: 100%;
 }
 
-#calendario table th.col-daily,
-#calendario table td.col-daily {
-  width: 46%;
+#calendario .mes-dropdown table tbody tr.dropdown {
+  display: block;
 }
 
-#calendario table th.col-cyclic,
-#calendario table td.col-cyclic {
-  width: 32%;
+#calendario .mes-dropdown table tbody tr.dropdown > td {
+  display: block;
+  width: 100%;
 }
 
 #calendario .mes-dropdown table thead th:first-child {


### PR DESCRIPTION
## Summary
- switch the calendar table layout to a CSS grid so the date, daily habit, and cyclic habit columns stay aligned with their headers
- update the calendar dropdown toggles to use block display values that match the new layout

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d288a34fd8832c851aeb2d6cb5483e