### PR TITLE
Center calendar dropdown rows

### DIFF
--- a/style.css
+++ b/style.css
@@ -462,6 +462,12 @@ th, td {
   border-collapse: separate;
 }
 
+#calendario .mes-dropdown table,
+#calendario .mes-dropdown table th,
+#calendario .mes-dropdown table td {
+  box-sizing: border-box;
+}
+
 #calendario .mes-dropdown table colgroup {
   display: none;
 }
@@ -500,7 +506,7 @@ th, td {
 }
 
 #calendario .mes-dropdown tr.dropdown td {
-  padding: 18px 18px 18px 34px;
+  padding: 18px 34px;
 }
 
 /* ==== Linhas principais === */


### PR DESCRIPTION
## Summary
- keep calendar dropdown rows within the CRT viewport by making their table cells use border-box sizing
- balance dropdown cell padding so the expanded content sits centered between the calendar edges

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2a5d97b28832caf2c6401d72e1871