### PR TITLE
Align calendar row text highlight with progress bar

### DIFF
--- a/style.css
+++ b/style.css
@@ -597,7 +597,7 @@ tr.main-row {
   position: absolute;
   inset: 0;
   color: var(--progress-covered-color, #000);
-  clip-path: inset(0 calc((1 - var(--day-progress, 0)) * 100%) 0 0);
+  clip-path: inset(0 var(--progress-cover-uncovered, 100%) 0 0);
   transition: clip-path 0.4s cubic-bezier(.55, .12, .32, 1.32);
   pointer-events: none;
   z-index: 2;


### PR DESCRIPTION
## Summary
- calculate per-row highlight coverage so progress text coloring lines up with the day progress bar
- refresh the highlight positioning when months are opened or the viewport is resized
- update the progress text clip-path styling to rely on the new computed offsets

## Testing
- Manual verification via local browser (Playwright)

------
https://chatgpt.com/codex/tasks/task_e_68da8ade461c832ca7883694d0cc07e1