### PR TITLE
Add weight tracking and adjust habit cadence

### DIFF
--- a/style.css
+++ b/style.css
@@ -771,6 +771,40 @@ tr.dropdown[style*="display: none;"] {
   box-shadow: 0 0 12px rgba(255, 227, 121, 0.45);
 }
 
+.habit-item.weight-habit {
+  border: 1px solid transparent;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  position: relative;
+}
+
+.habit-item.weight-habit.weight-filled {
+  border-color: rgba(255, 227, 121, 0.85);
+  box-shadow: 0 0 18px rgba(255, 227, 121, 0.35), 0 0 10px rgba(81, 255, 231, 0.25);
+}
+
+.habit-item.weight-habit.weight-filled::after {
+  content: 'PESO';
+  position: absolute;
+  top: -12px;
+  right: 18px;
+  background: linear-gradient(90deg, rgba(255, 227, 121, 0.9), rgba(81, 255, 231, 0.85));
+  color: #001130;
+  font-size: 0.48em;
+  letter-spacing: 0.18em;
+  padding: 6px 12px;
+  border-radius: 999px;
+  box-shadow: 0 0 12px rgba(255, 227, 121, 0.4);
+}
+
+.weight-latest {
+  margin-top: 10px;
+  font-size: 0.52em;
+  letter-spacing: 0.08em;
+  color: rgba(255, 227, 121, 0.9);
+  text-transform: uppercase;
+  display: none;
+}
+
 .diary-editor {
   margin-top: 22px;
   padding: 20px 22px 22px 22px;
@@ -778,6 +812,90 @@ tr.dropdown[style*="display: none;"] {
   border: 1px solid rgba(81, 255, 231, 0.55);
   background: linear-gradient(135deg, rgba(0, 17, 43, 0.82), rgba(0, 28, 60, 0.78));
   box-shadow: 0 0 22px rgba(81, 255, 231, 0.15), inset 0 0 16px rgba(0, 0, 0, 0.35);
+}
+
+.weight-editor {
+  margin-top: 18px;
+  padding: 18px 22px 20px 22px;
+  border-radius: 18px;
+  border: 1px solid rgba(255, 227, 121, 0.55);
+  background: linear-gradient(135deg, rgba(34, 15, 0, 0.85), rgba(12, 8, 0, 0.82));
+  box-shadow: 0 0 20px rgba(255, 227, 121, 0.18), inset 0 0 16px rgba(0, 0, 0, 0.35);
+}
+
+.weight-input-group {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 16px;
+}
+
+.weight-input {
+  width: 140px;
+  padding: 12px 14px;
+  border-radius: 12px;
+  border: 2px solid rgba(255, 227, 121, 0.75);
+  background: rgba(0, 0, 0, 0.45);
+  color: var(--highlight);
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.64em;
+  text-align: center;
+  letter-spacing: 0.08em;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.weight-input:focus {
+  border-color: rgba(255, 227, 121, 1);
+  box-shadow: 0 0 16px rgba(255, 227, 121, 0.35);
+}
+
+.weight-input-error {
+  border-color: rgba(255, 111, 111, 0.95) !important;
+  box-shadow: 0 0 16px rgba(255, 111, 111, 0.35) !important;
+}
+
+.weight-unit {
+  font-size: 0.6em;
+  letter-spacing: 0.12em;
+  color: rgba(255, 227, 121, 0.9);
+  text-transform: uppercase;
+}
+
+.weight-actions {
+  display: flex;
+  gap: 12px;
+}
+
+.weight-save,
+.weight-cancel {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.58em;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 10px 16px;
+  border-radius: 14px;
+  border: 2px solid rgba(255, 227, 121, 0.7);
+  background: rgba(30, 12, 0, 0.82);
+  color: var(--highlight);
+  cursor: pointer;
+  transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+}
+
+.weight-save:hover,
+.weight-cancel:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 20px rgba(255, 227, 121, 0.35);
+}
+
+.weight-save:active,
+.weight-cancel:active {
+  transform: translateY(1px) scale(0.98);
+}
+
+.weight-save:disabled {
+  opacity: 0.65;
+  cursor: not-allowed;
 }
 
 .diary-textarea {
@@ -874,6 +992,9 @@ tr.dropdown[style*="display: none;"] {
   transform: translate(-50%, 12px);
   display: flex;
   justify-content: center;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 12px;
   pointer-events: none;
   z-index: 40;
   opacity: 0;
@@ -893,11 +1014,11 @@ tr.dropdown[style*="display: none;"] {
 
 .diary-log-button {
   font-family: 'Press Start 2P', monospace;
-  font-size: 0.78em;
+  font-size: 0.6em;
   letter-spacing: 0.08em;
   text-transform: uppercase;
-  padding: 14px 28px;
-  border-radius: 20px;
+  padding: 10.5px 21px;
+  border-radius: 15px;
   border: 2px solid var(--neon);
   background: rgba(0, 18, 46, 0.72);
   color: var(--highlight);
@@ -922,7 +1043,26 @@ tr.dropdown[style*="display: none;"] {
   transform: translateY(1px) scale(0.98);
 }
 
+.diary-log-button.weight-log-button {
+  border-color: rgba(255, 227, 121, 0.85);
+}
+
+.diary-log-button.weight-log-button.active {
+  border-color: rgba(255, 227, 121, 1);
+  background: rgba(40, 26, 0, 0.9);
+  box-shadow: 0 0 26px rgba(255, 227, 121, 0.45), 0 0 30px rgba(255, 193, 7, 0.32);
+}
+
 .diary-log-panel {
+  display: none;
+  width: 100%;
+  flex: 1;
+  justify-content: center;
+  align-items: stretch;
+  padding: 24px 0 40px;
+}
+
+.weight-log-panel {
   display: none;
   width: 100%;
   flex: 1;
@@ -945,7 +1085,28 @@ tr.dropdown[style*="display: none;"] {
   overflow: hidden;
 }
 
+.weight-log-content {
+  width: min(820px, 94%);
+  height: 100%;
+  max-height: none;
+  background: linear-gradient(135deg, rgba(20, 8, 0, 0.94), rgba(34, 12, 0, 0.96));
+  border: 2px solid rgba(255, 227, 121, 0.82);
+  border-radius: 28px;
+  box-shadow: 0 0 40px rgba(255, 227, 121, 0.3), 0 0 60px rgba(255, 193, 7, 0.24);
+  padding: 28px 32px;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .diary-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+
+.weight-log-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -958,6 +1119,14 @@ tr.dropdown[style*="display: none;"] {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   text-shadow: 0 0 18px rgba(255, 227, 121, 0.6), 0 0 28px rgba(81, 255, 231, 0.35);
+}
+
+.weight-log-title {
+  color: rgba(255, 227, 121, 0.95);
+  font-size: 0.96em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-shadow: 0 0 18px rgba(255, 227, 121, 0.6), 0 0 28px rgba(255, 193, 7, 0.35);
 }
 
 .diary-log-close {
@@ -975,6 +1144,21 @@ tr.dropdown[style*="display: none;"] {
   transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
+.weight-log-close {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.6em;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border-radius: 14px;
+  padding: 10px 18px;
+  border: 2px solid rgba(255, 227, 121, 0.85);
+  background: rgba(40, 14, 0, 0.78);
+  color: rgba(255, 227, 121, 0.95);
+  cursor: pointer;
+  box-shadow: 0 0 18px rgba(255, 227, 121, 0.3);
+  transition: transform 0.18s ease, box-shadow 0.18s ease;
+}
+
 .diary-log-close:hover {
   transform: translateY(-2px);
   box-shadow: 0 0 22px rgba(255, 227, 121, 0.45);
@@ -984,11 +1168,161 @@ tr.dropdown[style*="display: none;"] {
   transform: translateY(1px) scale(0.98);
 }
 
+.weight-log-close:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 0 22px rgba(255, 227, 121, 0.42);
+}
+
+.weight-log-close:active {
+  transform: translateY(1px) scale(0.98);
+}
+
 .diary-log-list {
   flex: 1;
   overflow-y: auto;
   padding-right: 6px;
   margin-top: 12px;
+}
+
+.weight-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 18px;
+  margin-bottom: 24px;
+}
+
+.weight-stat {
+  background: linear-gradient(135deg, rgba(60, 22, 0, 0.9), rgba(30, 12, 0, 0.9));
+  border: 1px solid rgba(255, 227, 121, 0.55);
+  border-radius: 18px;
+  padding: 16px 18px;
+  box-shadow: 0 0 20px rgba(255, 227, 121, 0.2);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.weight-stat-label {
+  font-size: 0.56em;
+  letter-spacing: 0.18em;
+  color: rgba(255, 227, 121, 0.7);
+  text-transform: uppercase;
+}
+
+.weight-stat-value {
+  font-size: 0.8em;
+  letter-spacing: 0.08em;
+  color: rgba(255, 246, 209, 0.95);
+}
+
+.weight-chart-wrapper {
+  flex: 1;
+  background: linear-gradient(135deg, rgba(30, 12, 0, 0.78), rgba(12, 6, 0, 0.9));
+  border: 1px solid rgba(255, 227, 121, 0.35);
+  border-radius: 22px;
+  box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.6), 0 0 28px rgba(255, 193, 7, 0.22);
+  padding: 18px 18px 28px 18px;
+  margin-bottom: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.weight-chart {
+  width: 100%;
+  height: 100%;
+}
+
+.weight-chart-bg {
+  fill: none;
+}
+
+.weight-axis-line {
+  stroke: rgba(255, 227, 121, 0.35);
+  stroke-width: 1.4;
+}
+
+.weight-chart-line {
+  fill: none;
+  stroke: rgba(255, 143, 91, 0.9);
+  stroke-width: 3;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.weight-chart-point {
+  fill: rgba(255, 143, 91, 0.95);
+  stroke: rgba(255, 227, 121, 0.8);
+  stroke-width: 2.2;
+}
+
+.weight-chart-goal {
+  stroke: rgba(81, 255, 231, 0.65);
+  stroke-width: 2;
+  stroke-dasharray: 6 6;
+}
+
+.weight-chart-labels text {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.45em;
+  fill: rgba(255, 227, 121, 0.75);
+  text-anchor: middle;
+}
+
+.weight-chart-labels text.weight-axis-label {
+  text-anchor: end;
+  transform: translate(-6px, 4px);
+}
+
+.weight-axis-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.45em;
+  fill: rgba(255, 227, 121, 0.65);
+}
+
+.weight-goal-label {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.46em;
+  fill: rgba(81, 255, 231, 0.85);
+}
+
+.weight-empty {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.72em;
+  text-align: center;
+  color: rgba(255, 227, 121, 0.7);
+  margin: 40px 0 20px 0;
+}
+
+.weight-log-list {
+  flex: 1;
+  overflow-y: auto;
+  padding-right: 6px;
+  margin-top: 12px;
+}
+
+.weight-log-table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.weight-log-table th,
+.weight-log-table td {
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.58em;
+  letter-spacing: 0.08em;
+  color: rgba(255, 246, 209, 0.9);
+  padding: 12px 10px;
+  border-bottom: 1px solid rgba(255, 227, 121, 0.2);
+}
+
+.weight-log-table thead th {
+  text-transform: uppercase;
+  color: rgba(255, 227, 121, 0.85);
+}
+
+.weight-log-table tbody tr:hover {
+  background: rgba(255, 227, 121, 0.08);
 }
 
 .diary-log-item {
@@ -1037,6 +1371,23 @@ tr.dropdown[style*="display: none;"] {
 }
 
 #calendario.show-diary > :not(#diary-log-panel) {
+  display: none !important;
+}
+
+#calendario.show-weight {
+  align-items: center;
+  justify-content: center;
+  padding-top: 28px;
+  padding-bottom: 28px;
+  --top-mask-start: 0px;
+  --bottom-mask-stop: 0px;
+}
+
+#calendario.show-weight #weight-log-panel {
+  display: flex;
+}
+
+#calendario.show-weight > :not(#weight-log-panel) {
   display: none !important;
 }
 


### PR DESCRIPTION
## Summary
- introduce local storage and UI support for logging weights and viewing a progress chart alongside the diary controls
- adjust incremental habit onboarding to occur every three days and limit cyclic habits to weight check, diary, and tidying
- restyle action buttons and habit rows to accommodate the new weight workflow and status indicators

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbcf040288832c9434d7b85e53b0f1