### PR TITLE
Revamp reward portal animation and unify log panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -90,6 +90,11 @@
 
   <div id="reward-visualizer" aria-hidden="true">
     <div class="visualizer-backdrop"></div>
+    <div class="visualizer-tunnel" aria-hidden="true">
+      <span class="tunnel-layer tunnel-layer-one"></span>
+      <span class="tunnel-layer tunnel-layer-two"></span>
+      <span class="tunnel-layer tunnel-layer-three"></span>
+    </div>
     <div class="visualizer-warp" aria-hidden="true">
       <div class="warp-ring warp-ring-one"></div>
       <div class="warp-ring warp-ring-two"></div>

--- a/script.js
+++ b/script.js
@@ -965,7 +965,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
   });
 
-  const statusMargin = 32;
+  const statusMargin = 72;
 
   function positionLives(scale = currentScale) {
     if (!lifeContainer || !calendarioEl) return;
@@ -975,7 +975,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!calRect.width || !calRect.height) return;
     const parentRect = parent.getBoundingClientRect();
     const left = calRect.left - parentRect.left + statusMargin;
-    lifeContainer.style.left = `${left / scale}px`;
+    lifeContainer.style.left = `${Math.max(left, statusMargin) / scale}px`;
   }
 
   function positionLevel(scale = currentScale) {
@@ -986,7 +986,9 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!calRect.width || !calRect.height) return;
     const parentRect = parent.getBoundingClientRect();
     const rightInside = calRect.right - parentRect.left - statusMargin;
-    levelContainer.style.left = `${rightInside / scale}px`;
+    const containerWidth = (levelContainer.offsetWidth || 0) * scale;
+    const left = Math.max(statusMargin, rightInside - containerWidth);
+    levelContainer.style.left = `${left / scale}px`;
   }
 
   function positionDiaryButton(scale = currentScale) {
@@ -1291,11 +1293,13 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (!visualizerEl || !visualizerOpen) return;
     visualizerOpen = false;
     document.body.classList.remove('visualizer-portal');
+    document.body.classList.remove('visualizer-entering');
     visualizerEl.classList.remove('entering');
     visualizerEl.classList.add('closing');
     if (visualizerEnterTimeout) {
       clearTimeout(visualizerEnterTimeout);
       visualizerEnterTimeout = null;
+      document.body.classList.remove('visualizer-entering');
     }
     const focusTarget = visualizerEl.querySelector('.visualizer-content');
     if (focusTarget) focusTarget.removeAttribute('tabindex');
@@ -1322,6 +1326,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     if (visualizerEnterTimeout) {
       clearTimeout(visualizerEnterTimeout);
       visualizerEnterTimeout = null;
+      document.body.classList.remove('visualizer-entering');
     }
     visualizerEl.classList.remove('closing');
     applyVisualizerThemeStyles(theme);
@@ -1398,14 +1403,16 @@ document.addEventListener("DOMContentLoaded", async function () {
     visualizerEl.classList.add('show');
     document.body.classList.add('visualizer-portal');
     document.body.classList.add('visualizer-open');
+    document.body.classList.add('visualizer-entering');
     visualizerOpen = true;
     requestAnimationFrame(() => {
       visualizerEl.classList.add('entering');
     });
     visualizerEnterTimeout = setTimeout(() => {
       visualizerEl.classList.remove('entering');
+      document.body.classList.remove('visualizer-entering');
       visualizerEnterTimeout = null;
-    }, 1200);
+    }, 1300);
 
     const focusTarget = visualizerEl.querySelector('.visualizer-content');
     if (focusTarget) {

--- a/style.css
+++ b/style.css
@@ -82,6 +82,22 @@ body.visualizer-portal::before {
   animation: portalShadeIn 0.9s ease forwards;
   z-index: 50;
 }
+
+body.visualizer-entering #video-wrapper {
+  animation: screenSuck 1.2s cubic-bezier(.11, .75, .14, 1) forwards;
+}
+
+body.visualizer-entering::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  mix-blend-mode: screen;
+  background: radial-gradient(circle at center, rgba(81, 255, 231, 0.25) 0%, transparent 55%),
+              radial-gradient(circle at 50% 40%, rgba(207, 40, 255, 0.35) 0%, transparent 70%);
+  animation: tunnelFlash 1.2s ease forwards;
+  z-index: 55;
+}
 .arcade-bg {
   position: absolute;
   top: 0;
@@ -376,8 +392,7 @@ tr.main-row.sticky-title {
 #life-container,
 #level-container {
   position: absolute;
-  top: calc(4% - 30px - 0.5cm);
-  left: 0;
+  top: clamp(64px, 16%, 120px);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -385,17 +400,18 @@ tr.main-row.sticky-title {
   pointer-events: none;
   opacity: 0;
   overflow: visible;
-  transition: opacity 0.3s ease;
+  transition: opacity 0.3s ease, transform 0.3s ease;
   z-index: 26;
 }
 
 #life-container {
-  transform: none;
+  left: 0;
 }
 
 #level-container {
-  transform: translateX(-100%);
+  left: auto;
   text-align: right;
+  justify-content: flex-end;
 }
 
 #life-container.show,
@@ -1068,25 +1084,7 @@ tr.dropdown[style*="display: none;"] {
   transform: translateY(1px) scale(0.98);
 }
 
-.diary-log-button.weight-log-button {
-  background: rgba(40, 18, 0, 0.72);
-  box-shadow: 0 0 22px rgba(255, 227, 121, 0.32), 0 0 28px rgba(255, 193, 7, 0.22);
-}
-
-.diary-log-button.weight-log-button.active {
-  background: rgba(40, 26, 0, 0.85);
-  box-shadow: 0 0 28px rgba(81, 255, 231, 0.45), 0 0 34px rgba(255, 193, 7, 0.32);
-}
-
-.diary-log-panel {
-  display: none;
-  width: 100%;
-  flex: 1;
-  justify-content: center;
-  align-items: stretch;
-  padding: 24px 0 40px;
-}
-
+.diary-log-panel,
 .weight-log-panel {
   display: none;
   width: 100%;
@@ -1094,9 +1092,11 @@ tr.dropdown[style*="display: none;"] {
   justify-content: center;
   align-items: stretch;
   padding: 24px 0 40px;
+  min-height: 0;
 }
 
-.diary-log-content {
+.diary-log-content,
+.weight-log-content {
   width: min(820px, 94%);
   height: 100%;
   max-height: none;
@@ -1108,39 +1108,20 @@ tr.dropdown[style*="display: none;"] {
   display: flex;
   flex-direction: column;
   overflow: hidden;
+  min-height: 0;
 }
 
-.weight-log-content {
-  width: min(820px, 94%);
-  height: 100%;
-  max-height: none;
-  background: linear-gradient(135deg, rgba(20, 8, 0, 0.94), rgba(34, 12, 0, 0.96));
-  border: 2px solid rgba(255, 227, 121, 0.82);
-  border-radius: 28px;
-  box-shadow: 0 0 40px rgba(255, 227, 121, 0.3), 0 0 60px rgba(255, 193, 7, 0.24);
-  padding: 28px 32px;
-  display: flex;
-  flex-direction: column;
-  overflow-y: auto;
-  overflow-x: hidden;
-  scrollbar-gutter: stable;
-}
-
-.diary-log-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  margin-bottom: 18px;
-}
-
+.diary-log-header,
 .weight-log-header {
   display: flex;
   align-items: center;
   justify-content: space-between;
   margin-bottom: 18px;
+  gap: 18px;
 }
 
-.diary-log-title {
+.diary-log-title,
+.weight-log-title {
   color: var(--highlight);
   font-size: 0.96em;
   letter-spacing: 0.08em;
@@ -1148,15 +1129,8 @@ tr.dropdown[style*="display: none;"] {
   text-shadow: 0 0 18px rgba(255, 227, 121, 0.6), 0 0 28px rgba(81, 255, 231, 0.35);
 }
 
-.weight-log-title {
-  color: rgba(255, 227, 121, 0.95);
-  font-size: 0.96em;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  text-shadow: 0 0 18px rgba(255, 227, 121, 0.6), 0 0 28px rgba(255, 193, 7, 0.35);
-}
-
-.diary-log-close {
+.diary-log-close,
+.weight-log-close {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.6em;
   letter-spacing: 0.08em;
@@ -1171,44 +1145,27 @@ tr.dropdown[style*="display: none;"] {
   transition: transform 0.18s ease, box-shadow 0.18s ease;
 }
 
-.weight-log-close {
-  font-family: 'Press Start 2P', monospace;
-  font-size: 0.6em;
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
-  border-radius: 14px;
-  padding: 10px 18px;
-  border: 2px solid rgba(255, 227, 121, 0.85);
-  background: rgba(40, 14, 0, 0.78);
-  color: rgba(255, 227, 121, 0.95);
-  cursor: pointer;
-  box-shadow: 0 0 18px rgba(255, 227, 121, 0.3);
-  transition: transform 0.18s ease, box-shadow 0.18s ease;
-}
-
-.diary-log-close:hover {
+.diary-log-close:hover,
+.weight-log-close:hover {
   transform: translateY(-2px);
   box-shadow: 0 0 22px rgba(255, 227, 121, 0.45);
 }
 
-.diary-log-close:active {
-  transform: translateY(1px) scale(0.98);
-}
-
-.weight-log-close:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 0 22px rgba(255, 227, 121, 0.42);
-}
-
+.diary-log-close:active,
 .weight-log-close:active {
   transform: translateY(1px) scale(0.98);
 }
 
-.diary-log-list {
+
+
+.diary-log-list,
+.weight-log-list {
   flex: 1;
   overflow-y: auto;
   padding-right: 6px;
   margin-top: 12px;
+  min-height: 0;
+  scrollbar-gutter: stable both-edges;
 }
 
 .weight-stats {
@@ -1219,11 +1176,11 @@ tr.dropdown[style*="display: none;"] {
 }
 
 .weight-stat {
-  background: linear-gradient(135deg, rgba(60, 22, 0, 0.9), rgba(30, 12, 0, 0.9));
-  border: 1px solid rgba(255, 227, 121, 0.55);
+  background: rgba(0, 12, 36, 0.78);
+  border: 1px solid rgba(81, 255, 231, 0.5);
   border-radius: 18px;
   padding: 16px 18px;
-  box-shadow: 0 0 20px rgba(255, 227, 121, 0.2);
+  box-shadow: 0 0 16px rgba(81, 255, 231, 0.2);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -1232,22 +1189,22 @@ tr.dropdown[style*="display: none;"] {
 .weight-stat-label {
   font-size: 0.56em;
   letter-spacing: 0.18em;
-  color: rgba(255, 227, 121, 0.7);
+  color: rgba(103, 234, 255, 0.75);
   text-transform: uppercase;
 }
 
 .weight-stat-value {
   font-size: 0.8em;
   letter-spacing: 0.08em;
-  color: rgba(255, 246, 209, 0.95);
+  color: rgba(255, 255, 255, 0.86);
 }
 
 .weight-chart-wrapper {
   flex: 1;
-  background: linear-gradient(135deg, rgba(30, 12, 0, 0.78), rgba(12, 6, 0, 0.9));
-  border: 1px solid rgba(255, 227, 121, 0.35);
+  background: linear-gradient(135deg, rgba(0, 18, 46, 0.82), rgba(0, 10, 28, 0.9));
+  border: 1px solid rgba(81, 255, 231, 0.35);
   border-radius: 22px;
-  box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.6), 0 0 28px rgba(255, 193, 7, 0.22);
+  box-shadow: inset 0 0 22px rgba(0, 0, 0, 0.6), 0 0 28px rgba(81, 255, 231, 0.22);
   padding: 18px 18px 28px 18px;
   margin-bottom: 24px;
   display: flex;
@@ -1265,26 +1222,26 @@ tr.dropdown[style*="display: none;"] {
 }
 
 .weight-axis-line {
-  stroke: rgba(255, 227, 121, 0.35);
+  stroke: rgba(81, 255, 231, 0.35);
   stroke-width: 1.4;
 }
 
 .weight-chart-line {
   fill: none;
-  stroke: rgba(255, 143, 91, 0.9);
+  stroke: rgba(81, 255, 231, 0.88);
   stroke-width: 3;
   stroke-linecap: round;
   stroke-linejoin: round;
 }
 
 .weight-chart-point {
-  fill: rgba(255, 143, 91, 0.95);
-  stroke: rgba(255, 227, 121, 0.8);
+  fill: rgba(207, 40, 255, 0.9);
+  stroke: rgba(81, 255, 231, 0.8);
   stroke-width: 2.2;
 }
 
 .weight-chart-goal {
-  stroke: rgba(81, 255, 231, 0.65);
+  stroke: rgba(255, 227, 121, 0.65);
   stroke-width: 2;
   stroke-dasharray: 6 6;
 }
@@ -1292,7 +1249,7 @@ tr.dropdown[style*="display: none;"] {
 .weight-chart-labels text {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.45em;
-  fill: rgba(255, 227, 121, 0.75);
+  fill: rgba(103, 234, 255, 0.75);
   text-anchor: middle;
 }
 
@@ -1304,29 +1261,23 @@ tr.dropdown[style*="display: none;"] {
 .weight-axis-label {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.45em;
-  fill: rgba(255, 227, 121, 0.65);
+  fill: rgba(103, 234, 255, 0.65);
 }
 
 .weight-goal-label {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.46em;
-  fill: rgba(81, 255, 231, 0.85);
+  fill: rgba(255, 227, 121, 0.9);
 }
 
 .weight-empty {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.72em;
   text-align: center;
-  color: rgba(255, 227, 121, 0.7);
+  color: rgba(103, 234, 255, 0.7);
   margin: 40px 0 20px 0;
 }
 
-.weight-log-list {
-  flex: 1;
-  overflow-y: auto;
-  padding-right: 6px;
-  margin-top: 12px;
-}
 
 .weight-log-table {
   width: 100%;
@@ -1338,18 +1289,18 @@ tr.dropdown[style*="display: none;"] {
   font-family: 'Press Start 2P', monospace;
   font-size: 0.58em;
   letter-spacing: 0.08em;
-  color: rgba(255, 246, 209, 0.9);
+  color: rgba(255, 255, 255, 0.85);
   padding: 12px 10px;
-  border-bottom: 1px solid rgba(255, 227, 121, 0.2);
+  border-bottom: 1px solid rgba(81, 255, 231, 0.18);
 }
 
 .weight-log-table thead th {
   text-transform: uppercase;
-  color: rgba(255, 227, 121, 0.85);
+  color: var(--text-neon);
 }
 
 .weight-log-table tbody tr:hover {
-  background: rgba(255, 227, 121, 0.08);
+  background: rgba(81, 255, 231, 0.08);
 }
 
 .diary-log-item {
@@ -1391,6 +1342,7 @@ tr.dropdown[style*="display: none;"] {
   padding-bottom: 28px;
   --top-mask-start: 0px;
   --bottom-mask-stop: 0px;
+  overflow: hidden;
 }
 
 #calendario.show-diary #diary-log-panel {
@@ -1408,6 +1360,7 @@ tr.dropdown[style*="display: none;"] {
   padding-bottom: 28px;
   --top-mask-start: 0px;
   --bottom-mask-stop: 0px;
+  overflow: hidden;
 }
 
 #calendario.show-weight #weight-log-panel {
@@ -1421,6 +1374,7 @@ tr.dropdown[style*="display: none;"] {
 .diary-log-table {
   width: 100%;
   border-collapse: collapse;
+  table-layout: fixed;
 }
 
 .diary-log-table thead tr {
@@ -1434,23 +1388,37 @@ tr.dropdown[style*="display: none;"] {
   letter-spacing: 0.08em;
   text-transform: uppercase;
   padding: 10px 12px;
+  text-align: left;
+  vertical-align: bottom;
 }
 
 .diary-log-table td {
   padding: 10px 12px;
   background: transparent !important;
+  text-align: left;
+  vertical-align: top;
 }
 
-.diary-log-row td:first-child {
-  width: 38%;
+.diary-log-table th:first-child,
+.diary-log-table td:first-child {
+  width: 32%;
+}
+
+.diary-log-table th:last-child,
+.diary-log-table td:last-child {
+  width: 68%;
 }
 
 .diary-log-row .diary-log-preview {
-  display: block;
+  display: -webkit-box;
   font-size: 0.62em;
   color: rgba(255, 255, 255, 0.78);
   letter-spacing: 0.03em;
   line-height: 1.6;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  min-height: calc(2 * 1.6em);
 }
 
 .diary-log-dropdown td {
@@ -1843,6 +1811,10 @@ body.visualizer-open {
   z-index: 1;
 }
 
+#reward-visualizer.entering .visualizer-backdrop {
+  animation: backdropDrift 18s ease-in-out infinite, tunnelBackdrop 1.2s cubic-bezier(.11, .75, .14, 1) forwards;
+}
+
 #reward-visualizer::before {
   content: "";
   position: absolute;
@@ -1850,6 +1822,55 @@ body.visualizer-open {
   background: radial-gradient(circle, var(--visual-primary) 0%, transparent 60%);
   opacity: 0.22;
   mix-blend-mode: screen;
+}
+
+#reward-visualizer .visualizer-tunnel {
+  position: absolute;
+  inset: -10vmax;
+  display: grid;
+  place-items: center;
+  pointer-events: none;
+  z-index: 3;
+  opacity: 0;
+}
+
+#reward-visualizer.entering .visualizer-tunnel {
+  animation: tunnelFade 1.2s ease forwards;
+}
+
+.visualizer-tunnel .tunnel-layer {
+  position: absolute;
+  width: clamp(40vmax, 72vw, 90vmax);
+  height: clamp(40vmax, 72vw, 90vmax);
+  border-radius: 50%;
+  border: 6px solid transparent;
+  mix-blend-mode: screen;
+  opacity: 0;
+  filter: blur(2px);
+}
+
+.visualizer-tunnel .tunnel-layer-one {
+  border-color: rgba(81, 255, 231, 0.8);
+}
+
+.visualizer-tunnel .tunnel-layer-two {
+  border-color: rgba(207, 40, 255, 0.7);
+}
+
+.visualizer-tunnel .tunnel-layer-three {
+  border-color: rgba(255, 227, 121, 0.6);
+}
+
+#reward-visualizer.entering .tunnel-layer-one {
+  animation: tunnelLayerOne 1.2s cubic-bezier(.11, .75, .14, 1) forwards;
+}
+
+#reward-visualizer.entering .tunnel-layer-two {
+  animation: tunnelLayerTwo 1.2s cubic-bezier(.11, .75, .14, 1) 0.08s forwards;
+}
+
+#reward-visualizer.entering .tunnel-layer-three {
+  animation: tunnelLayerThree 1.2s cubic-bezier(.11, .75, .14, 1) 0.16s forwards;
 }
 
 #reward-visualizer .visualizer-warp {
@@ -1891,6 +1912,10 @@ body.visualizer-open {
   animation: warpRing 12s linear infinite;
 }
 
+#reward-visualizer.entering .warp-ring {
+  animation: warpRingBurst 1.2s cubic-bezier(.11, .75, .14, 1) forwards;
+}
+
 #reward-visualizer .warp-ring-two {
   animation-delay: -4s;
   border-color: var(--visual-warp-end);
@@ -1925,6 +1950,16 @@ body.visualizer-open {
   z-index: 5;
 }
 
+#reward-visualizer.entering .visualizer-particles {
+  opacity: 0;
+  filter: blur(6px);
+}
+
+#reward-visualizer.show:not(.entering) .visualizer-particles {
+  opacity: 1;
+  filter: none;
+}
+
 #reward-visualizer .visualizer-haze {
   position: absolute;
   inset: 0;
@@ -1934,6 +1969,10 @@ body.visualizer-open {
   pointer-events: none;
   animation: portalHaze 8s ease-in-out infinite;
   z-index: 4;
+}
+
+#reward-visualizer.entering .visualizer-haze {
+  animation: portalHaze 8s ease-in-out infinite, tunnelHaze 1.2s cubic-bezier(.11, .75, .14, 1) forwards;
 }
 
 #reward-visualizer .visualizer-particles span {
@@ -1950,6 +1989,70 @@ body.visualizer-open {
   15% { opacity: 0.65; }
   45% { opacity: 0.9; }
   100% { transform: translate3d(0, -280px, 0) scale(1.6); opacity: 0; }
+}
+
+@keyframes tunnelFade {
+  0% { opacity: 0; }
+  20% { opacity: 0.35; }
+  55% { opacity: 0.85; }
+  100% { opacity: 0; }
+}
+
+@keyframes tunnelLayerOne {
+  0% { transform: scale(0.25); opacity: 0; }
+  35% { opacity: 0.9; }
+  100% { transform: scale(1.3); opacity: 0; filter: blur(12px); }
+}
+
+@keyframes tunnelLayerTwo {
+  0% { transform: scale(0.18); opacity: 0; }
+  45% { opacity: 0.75; }
+  100% { transform: scale(1.6); opacity: 0; filter: blur(18px); }
+}
+
+@keyframes tunnelLayerThree {
+  0% { transform: scale(0.12); opacity: 0; }
+  55% { opacity: 0.6; }
+  100% { transform: scale(1.9); opacity: 0; filter: blur(24px); }
+}
+
+@keyframes warpRingBurst {
+  0% { transform: scale(0.45); opacity: 0.1; }
+  45% { opacity: 0.6; }
+  100% { transform: scale(1.9); opacity: 0; }
+}
+
+@keyframes screenSuck {
+  0% {
+    transform: perspective(1600px) translate3d(var(--wrapper-translate-x), var(--wrapper-translate-y), 0) scale(var(--wrapper-scale));
+    filter: brightness(1) saturate(100%) blur(0);
+  }
+  60% {
+    transform: perspective(2000px) translate3d(calc(var(--wrapper-translate-x) - 30px), calc(var(--wrapper-translate-y) - 30px), -90px) scale(calc(var(--wrapper-scale) * 0.9)) rotateX(8deg);
+    filter: brightness(0.55) saturate(160%) blur(3px);
+  }
+  100% {
+    transform: perspective(2200px) translate3d(calc(var(--wrapper-translate-x) - 48px), calc(var(--wrapper-translate-y) - 48px), -160px) scale(calc(var(--wrapper-scale) * 0.82)) rotateX(12deg);
+    filter: brightness(0.42) saturate(195%) blur(5px);
+  }
+}
+
+@keyframes tunnelBackdrop {
+  0% { transform: scale(1); filter: blur(0); opacity: 0.6; }
+  100% { transform: scale(1.3); filter: blur(6px); opacity: 0.2; }
+}
+
+@keyframes tunnelFlash {
+  0% { opacity: 0; }
+  20% { opacity: 0.65; }
+  55% { opacity: 0.4; }
+  100% { opacity: 0; }
+}
+
+@keyframes tunnelHaze {
+  0% { opacity: 0.12; filter: blur(0); }
+  55% { opacity: 0.42; filter: blur(4px); }
+  100% { opacity: 0.18; filter: blur(0); }
 }
 
 @keyframes warpRing {
@@ -1977,9 +2080,9 @@ body.visualizer-open {
 }
 
 @keyframes contentDrop {
-  0% { opacity: 0; transform: translate3d(0, -60px, 120px) scale(0.9); }
-  60% { opacity: 1; transform: translate3d(0, 12px, 0) scale(1.01); }
-  100% { opacity: 1; transform: translate3d(0, 0, 0) scale(1); }
+  0% { opacity: 0; transform: translate3d(0, 140px, -240px) scale(0.88); filter: blur(6px); }
+  55% { opacity: 1; transform: translate3d(0, -18px, 60px) scale(1.04); filter: blur(1px); }
+  100% { opacity: 1; transform: translate3d(0, 0, 0) scale(1); filter: blur(0); }
 }
 
 @keyframes contentExit {
@@ -2037,16 +2140,25 @@ body.visualizer-open {
   color: #f5f8ff;
   transform: translate3d(0, 0, 0) scale(1);
   opacity: 0;
+  filter: none;
   transition: opacity 0.45s ease, transform 0.6s cubic-bezier(.16, .84, .44, 1);
   z-index: 10;
 }
 
 #reward-visualizer.show .visualizer-content {
-  opacity: 1;
+  opacity: 0;
 }
 
 #reward-visualizer.entering .visualizer-content {
-  animation: contentDrop 1.05s cubic-bezier(.12, .82, .21, 1.01) forwards;
+  opacity: 0;
+  transform: translate3d(0, 160px, -320px) scale(0.38) rotateX(18deg);
+  filter: blur(6px);
+}
+
+#reward-visualizer.show:not(.entering) .visualizer-content {
+  opacity: 1;
+  filter: none;
+  animation: contentDrop 0.9s cubic-bezier(.12, .82, .21, 1.01) forwards;
 }
 
 #reward-visualizer.closing .visualizer-content {


### PR DESCRIPTION
## Summary
- add a tunnel-style intro sequence before the reward portal opens to make the celebration more dramatic
- reposition the life and level counters and restyle diary/weight controls so they share the same look and spacing
- align diary table columns, clamp previews, and fix scrolling for diary and weight history panels

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68dc8fdeef50832ca5b8281d3a95c4a8