### PR TITLE
Ajusta HUD, diário e animação do visualizer

### DIFF
--- a/script.js
+++ b/script.js
@@ -1645,15 +1645,17 @@ document.addEventListener("DOMContentLoaded", async function () {
       const plain = (entry.texto || '').replace(/\s+/g, ' ').trim();
       const previewBase = plain.length ? plain : 'Entrada registrada';
       const preview = previewBase.length > 120 ? previewBase.slice(0, 117) + '…' : previewBase;
+      const previewSafe = escapeHTML(preview);
+      const displayDateSafe = escapeHTML(entry.displayDate || '');
       return `
         <tr class="main-row arcade-clicavel diary-log-row" data-day="${dayId}">
-          <td class="progress-text gold">${renderProgressText(entry.displayDate)}</td>
-          <td class="progress-text gold">${renderProgressText(preview, 'diary-log-preview')}</td>
+          <td class="diary-log-date-cell">${displayDateSafe}</td>
+          <td class="diary-log-summary-cell"><span class="diary-log-preview">${previewSafe}</span></td>
         </tr>
         <tr class="dropdown diary-log-dropdown" data-day="${dayId}" style="display: none;">
           <td colspan="2">
             <div class="diary-log-item" data-day="${dayId}">
-              <div class="diary-log-date">${entry.displayDate}</div>
+              <div class="diary-log-date">${displayDateSafe}</div>
               <div class="diary-log-text">${safeText}</div>
             </div>
           </td>
@@ -1663,8 +1665,8 @@ document.addEventListener("DOMContentLoaded", async function () {
       <table class="diary-log-table">
         <thead>
           <tr>
-            <th>Data</th>
-            <th>Resumo</th>
+            <th class="diary-log-date-header">Data</th>
+            <th class="diary-log-summary-header">Resumo</th>
           </tr>
         </thead>
         <tbody>${itemsHtml}</tbody>

--- a/style.css
+++ b/style.css
@@ -392,7 +392,7 @@ tr.main-row.sticky-title {
 #life-container,
 #level-container {
   position: absolute;
-  top: clamp(64px, 16%, 120px);
+  top: clamp(20px, 6%, 80px);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -1165,7 +1165,15 @@ tr.dropdown[style*="display: none;"] {
   padding-right: 6px;
   margin-top: 12px;
   min-height: 0;
-  scrollbar-gutter: stable both-edges;
+  -webkit-overflow-scrolling: touch;
+  touch-action: pan-y;
+  scrollbar-width: none;
+}
+
+.diary-log-list::-webkit-scrollbar,
+.weight-log-list::-webkit-scrollbar {
+  width: 0;
+  height: 0;
 }
 
 .weight-stats {
@@ -1399,6 +1407,25 @@ tr.dropdown[style*="display: none;"] {
   vertical-align: top;
 }
 
+.diary-log-date-header,
+.diary-log-date-cell {
+  width: 32%;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.62em;
+  letter-spacing: 0.08em;
+  color: var(--text-neon);
+  text-transform: uppercase;
+}
+
+.diary-log-summary-header,
+.diary-log-summary-cell {
+  width: 68%;
+  font-family: 'Press Start 2P', monospace;
+  font-size: 0.62em;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.82);
+}
+
 .diary-log-table th:first-child,
 .diary-log-table td:first-child {
   width: 32%;
@@ -1419,6 +1446,7 @@ tr.dropdown[style*="display: none;"] {
   -webkit-box-orient: vertical;
   overflow: hidden;
   min-height: calc(2 * 1.6em);
+  word-break: break-word;
 }
 
 .diary-log-dropdown td {
@@ -2028,12 +2056,12 @@ body.visualizer-open {
     filter: brightness(1) saturate(100%) blur(0);
   }
   60% {
-    transform: perspective(2000px) translate3d(calc(var(--wrapper-translate-x) - 30px), calc(var(--wrapper-translate-y) - 30px), -90px) scale(calc(var(--wrapper-scale) * 0.9)) rotateX(8deg);
-    filter: brightness(0.55) saturate(160%) blur(3px);
+    transform: perspective(1400px) translate3d(calc(var(--wrapper-translate-x) + 26px), calc(var(--wrapper-translate-y) + 26px), 160px) scale(calc(var(--wrapper-scale) * 1.18)) rotateX(6deg);
+    filter: brightness(1.28) saturate(145%) blur(2px);
   }
   100% {
-    transform: perspective(2200px) translate3d(calc(var(--wrapper-translate-x) - 48px), calc(var(--wrapper-translate-y) - 48px), -160px) scale(calc(var(--wrapper-scale) * 0.82)) rotateX(12deg);
-    filter: brightness(0.42) saturate(195%) blur(5px);
+    transform: perspective(1200px) translate3d(calc(var(--wrapper-translate-x) + 42px), calc(var(--wrapper-translate-y) + 42px), 320px) scale(calc(var(--wrapper-scale) * 1.34)) rotateX(9deg);
+    filter: brightness(1.44) saturate(168%) blur(1.5px);
   }
 }
 


### PR DESCRIPTION
## Summary
- reposiciona os indicadores de vidas e nível para ficarem acima do calendário sem sobrepor o conteúdo
- corrige a renderização do registro do diário exibindo resumo alinhado às colunas, com datas e texto seguros
- remove barras de rolagem visíveis nos painéis de diário e peso e ajusta a animação de entrada do visualizer para aproximar a câmera

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd14cfcb08832cbdfe8ee9a1b77725