### PR TITLE
Raise status indicators above calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -392,7 +392,7 @@ tr.main-row.sticky-title {
 #life-container,
 #level-container {
   position: absolute;
-  top: clamp(20px, 6%, 80px);
+  top: clamp(-110px, -10vh, 18px);
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Summary
- raise the absolute position of the life and level indicators so they sit above the calendar mask

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd192efd00832cb20ffa34b8d64d93