### PR TITLE
Adjust HUD status position above calendar

### DIFF
--- a/style.css
+++ b/style.css
@@ -392,7 +392,7 @@ tr.main-row.sticky-title {
 #life-container,
 #level-container {
   position: absolute;
-  top: clamp(20px, 6%, 80px);
+  top: clamp(-60px, -6%, 24px);
   display: flex;
   align-items: center;
   gap: 8px;
@@ -409,7 +409,7 @@ tr.main-row.sticky-title {
 }
 
 #level-container {
-  left: auto;
+  right: 0;
   text-align: right;
   justify-content: flex-end;
 }


### PR DESCRIPTION
## Summary
- raise the life and level status containers so they sit above the calendar content
- anchor the level display to the right edge to prevent overlap with the calendar

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd192efd00832cb20ffa34b8d64d93