### PR TITLE
Adjust status indicators spacing around calendar

### DIFF
--- a/script.js
+++ b/script.js
@@ -965,7 +965,7 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
   });
 
-  const statusMargin = 72;
+  const statusMargin = 72 + 38; // base offset plus ~1cm for symmetric spacing
 
   function positionLives(scale = currentScale) {
     if (!lifeContainer || !calendarioEl) return;

--- a/style.css
+++ b/style.css
@@ -392,7 +392,7 @@ tr.main-row.sticky-title {
 #life-container,
 #level-container {
   position: absolute;
-  top: clamp(-60px, -6%, 24px);
+  top: calc(clamp(-60px, -6%, 24px) + 0.5cm);
   display: flex;
   align-items: center;
   gap: 8px;


### PR DESCRIPTION
## Summary
- lower the life and level overlays slightly to better match the cabinet artwork
- increase the calendar status margin so the level indicator mirrors the lives offset on the right side

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68dd1c3fd76c832c9d7b0fd05a77d3b7