### PR TITLE
Hide status indicators until gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -63,15 +63,17 @@
       </div>
       <div id="sticky-title-overlay" aria-hidden="true"></div>
       <div id="calendario" class="calendario-container" tabindex="-1" style="display:none;"></div>
-      <div id="life-container" style="display:none;">
-        <span class="life-label">Vidas</span>
-        <span class="life-heart">❤️</span>
-        <span class="life-heart">❤️</span>
-        <span class="life-heart">❤️</span>
-      </div>
-      <div id="level-container" style="display:none;">
-        <span class="level-label">Nível</span>
-        <span class="level-value">0</span>
+      <div id="status-indicators">
+        <div id="life-container" style="display:none;">
+          <span class="life-label">Vidas</span>
+          <span class="life-heart">❤️</span>
+          <span class="life-heart">❤️</span>
+          <span class="life-heart">❤️</span>
+        </div>
+        <div id="level-container" style="display:none;">
+          <span class="level-label">Nível</span>
+          <span class="level-value">0</span>
+        </div>
       </div>
     </div>
   </div>

--- a/script.js
+++ b/script.js
@@ -868,6 +868,7 @@ document.addEventListener("DOMContentLoaded", async function () {
   const countersEl = document.querySelector('.arcade-counters');
   const lifeContainer = document.getElementById('life-container');
   const levelContainer = document.getElementById('level-container');
+  const statusIndicators = document.getElementById('status-indicators');
   const videoWrapper = document.getElementById('video-wrapper');
   const visualizerEl = document.getElementById('reward-visualizer');
   const visualizerIconEl = visualizerEl ? visualizerEl.querySelector('.visualizer-icon') : null;
@@ -965,30 +966,22 @@ document.addEventListener("DOMContentLoaded", async function () {
     }
   });
 
-  const statusMargin = 72 + 38; // base offset plus ~1cm for symmetric spacing
-
   function positionLives(scale = currentScale) {
-    if (!lifeContainer || !calendarioEl) return;
-    const parent = lifeContainer.parentElement;
-    if (!parent) return;
-    const calRect = calendarioEl.getBoundingClientRect();
-    if (!calRect.width || !calRect.height) return;
-    const parentRect = parent.getBoundingClientRect();
-    const left = calRect.left - parentRect.left + statusMargin;
-    lifeContainer.style.left = `${Math.max(left, statusMargin) / scale}px`;
+    if (!lifeContainer) return;
+    lifeContainer.style.removeProperty('left');
+    lifeContainer.style.removeProperty('right');
+    if (statusIndicators) {
+      statusIndicators.style.transform = 'translateX(-50%)';
+    }
   }
 
   function positionLevel(scale = currentScale) {
-    if (!levelContainer || !calendarioEl) return;
-    const parent = levelContainer.parentElement;
-    if (!parent) return;
-    const calRect = calendarioEl.getBoundingClientRect();
-    if (!calRect.width || !calRect.height) return;
-    const parentRect = parent.getBoundingClientRect();
-    const rightInside = calRect.right - parentRect.left - statusMargin;
-    const containerWidth = (levelContainer.offsetWidth || 0) * scale;
-    const left = Math.max(statusMargin, rightInside - containerWidth);
-    levelContainer.style.left = `${left / scale}px`;
+    if (!levelContainer) return;
+    levelContainer.style.removeProperty('left');
+    levelContainer.style.removeProperty('right');
+    if (statusIndicators) {
+      statusIndicators.style.transform = 'translateX(-50%)';
+    }
   }
 
   function positionDiaryButton(scale = currentScale) {
@@ -1091,6 +1084,9 @@ document.addEventListener("DOMContentLoaded", async function () {
       if (calendarioEl) {
         calendarioEl.style.display = '';
         calendarioEl.classList.add('show-rgb');
+      }
+      if (statusIndicators) {
+        statusIndicators.classList.add('active');
       }
       if (countersEl) {
         countersEl.style.display = '';

--- a/style.css
+++ b/style.css
@@ -390,10 +390,29 @@ tr.main-row.sticky-title {
 }
 
 /* === STATUS INDICATORS === */
-#life-container,
-#level-container {
+#status-indicators {
   position: absolute;
   top: calc(clamp(-60px, -6%, 24px) + 0.5cm - 3mm);
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 6cm;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 0.35s ease;
+  z-index: 26;
+}
+
+#status-indicators.active {
+  opacity: 1;
+  visibility: visible;
+}
+
+#life-container,
+#level-container {
   display: flex;
   align-items: center;
   gap: 8px;
@@ -402,15 +421,9 @@ tr.main-row.sticky-title {
   opacity: 0;
   overflow: visible;
   transition: opacity 0.3s ease, transform 0.3s ease;
-  z-index: 26;
-}
-
-#life-container {
-  left: var(--status-indicator-gutter);
 }
 
 #level-container {
-  right: var(--status-indicator-gutter);
   text-align: right;
   justify-content: flex-end;
 }


### PR DESCRIPTION
## Summary
- keep the shared status indicator strip hidden and invisible by default
- activate the indicator strip once the calendar is revealed so it no longer shows on the title screen

## Testing
- not run (not run)

------
https://chatgpt.com/codex/tasks/task_e_68dd358937f8832c8eb1f400570abc26